### PR TITLE
Better search

### DIFF
--- a/assets/components/header/index.js
+++ b/assets/components/header/index.js
@@ -32,7 +32,7 @@ export default class Header extends Component {
 		return (
 			<header class="elevated">
 				<span class="nav-set">
-					{view === '/entries' &&
+					{view === '/entries' && !showFilterInput &&
 						<h3>Entries</h3>
 					}
 

--- a/assets/components/header/index.js
+++ b/assets/components/header/index.js
@@ -29,10 +29,11 @@ export default class Header extends Component {
 
 	render({view, loggedIn, entry, filterText, showFilterInput, dark}) {
 		if(!loggedIn) return null;
+		let vw = window.innerWidth;
 		return (
 			<header class="elevated">
 				<span class="nav-set">
-					{view === '/entries' && !showFilterInput &&
+					{view === '/entries' && (vw > 400 || !showFilterInput) &&
 						<h3>Entries</h3>
 					}
 

--- a/assets/js/actions/entry-actions.js
+++ b/assets/js/actions/entry-actions.js
@@ -258,25 +258,25 @@ function newEntry (el){
 
 function filterByText (el, text, e){
   if(text === undefined && (!e || !e.target)) return;
-  let value = text === undefined ? e.target.value : text;
-  if(el.state.filterText === value) return;
-  if(!value) return el.setState({
+  let query = text === undefined ? e.target.value : text;
+  if(el.state.filterText === query) return;
+  if(!query) return el.setState({
     filterText: '',
     viewEntries: applyFilters('', el.state.entries)
   });
 
   // If the new query is a continuation of the prior query,
   // fitler viewEntries for efficiency.
-  var query = value;
   var q = query.toLowerCase();
-  var entries = (q.indexOf(el.state.filterText) === 0)
+  var f = el.state.filterText;
+  var entries = (q.length > f.length && q.indexOf(f) === 0)
     ? el.state.viewEntries
     : el.state.entries;
+  entries = [].concat(entries);
 
-  var viewEntries = applyFilters(q, entries);
   el.setState({
     filterText: query,
-    viewEntries: viewEntries
+    viewEntries: applyFilters(q, entries)
   });
 };
 

--- a/assets/js/actions/entry-actions.js
+++ b/assets/js/actions/entry-actions.js
@@ -230,7 +230,7 @@ function deleteEntryFailure (el, err){
   console.log('deleteEntryFailure', err);
 };
 
-function setEntry (el, { id/*, entryReady*/ }){
+function setEntry (el, { id }){
   if(!id || id === -1) return;
 
   var entryIndex = findObjectIndexById(parseInt(id), el.state.entries);
@@ -272,7 +272,6 @@ function filterByText (el, text, e){
   var entries = (q.length > f.length && q.indexOf(f) === 0)
     ? el.state.viewEntries
     : el.state.entries;
-  entries = [].concat(entries);
 
   el.setState({
     filterText: query,

--- a/assets/js/utils/index.js
+++ b/assets/js/utils/index.js
@@ -18,10 +18,17 @@ function sortObjectsByDate (list) {
 
 function filterObjectsByText (query, list) {
   if(!query) return list;
-  return list.filter(function(obj){
-    return ~obj.text.toLowerCase().indexOf(query)
-      || ~obj.date.indexOf(query);
-  });
+  return list.reduce(function(accumulator, obj){
+    var index = obj.text.toLowerCase().indexOf(query);
+    if(index > -1){
+      obj = Object.assign({}, obj);
+      obj.text = obj.text.substr(Math.max(0, index - 10));
+      accumulator.push(obj);
+    } else if(obj.date === query) {
+      accumulator.push(obj);
+    }
+    return accumulator;
+  }, []);
 };
 
 function filterHiddenEntries (entries) {

--- a/assets/js/utils/index.js
+++ b/assets/js/utils/index.js
@@ -22,7 +22,7 @@ function filterObjectsByText (query, list) {
     var index = obj.text.toLowerCase().indexOf(query);
     if(index > -1){
       obj = Object.assign({}, obj);
-      index = Math.max(0, index - 10);
+      index = Math.max(0, index - 40);
       var ellipses = index ? '...' : '';
       obj.text = ellipses + obj.text.substr(index);
       accumulator.push(obj);

--- a/assets/js/utils/index.js
+++ b/assets/js/utils/index.js
@@ -22,7 +22,9 @@ function filterObjectsByText (query, list) {
     var index = obj.text.toLowerCase().indexOf(query);
     if(index > -1){
       obj = Object.assign({}, obj);
-      obj.text = obj.text.substr(Math.max(0, index - 10));
+      index = Math.max(0, index - 10);
+      var ellipses = index ? '...' : '';
+      obj.text = ellipses + obj.text.substr(index);
       accumulator.push(obj);
     } else if(obj.date === query) {
       accumulator.push(obj);

--- a/assets/js/utils/index.js
+++ b/assets/js/utils/index.js
@@ -20,13 +20,13 @@ function filterObjectsByText (query, list) {
   if(!query) return list;
   return list.reduce(function(accumulator, obj){
     var index = obj.text.toLowerCase().indexOf(query);
-    if(index > -1){
+    if(~index){
       obj = Object.assign({}, obj);
       index = Math.max(0, index - 40);
       var ellipses = index ? '...' : '';
       obj.text = ellipses + obj.text.substr(index);
       accumulator.push(obj);
-    } else if(obj.date === query) {
+    } else if(~obj.date.indexOf(query)) {
       accumulator.push(obj);
     }
     return accumulator;


### PR DESCRIPTION
* Ensuring matching entry previews show the subset of the text that contains the first instance of the query
* Hiding the "Entries" header while the search input is visible on small screens
* Getting rid of an old, commented  `entryReady` argument