### PR TITLE
Computed properties via getters and setters.

### DIFF
--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -20,7 +20,7 @@ export default class Entries extends Component {
     entries = entries || [];
     if(!entries.length){
       return (
-        <h2 class="center-text">It's empty in here!</h2>
+        <h2 class="center-text fly">It's empty in here!</h2>
       );
     }
     return (

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -28,7 +28,7 @@ function getAllEntries (el){
 
 function getAllEntriesSuccess (el, response){
   persist(el, {
-    setEntries: response.entries,
+    entries: response.entries,
   }, function(){
     localStorage.setItem('timestamp', response.timestamp);
   });
@@ -89,7 +89,7 @@ function applySyncPatch (el, entries){
 
 function persistSyncPatch (el, timestamp){
   persist(el, {
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   }, function(){
     if(el.state.view === '/entry' && el.state.entryId){
       setEntry(el, {id: el.state.entryId});
@@ -108,14 +108,14 @@ function createEntry (el, { entry, clientSync }){
 
   persist(el, {
     entry: entry,
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 
   if(!clientSync && entry.postPending) return;
 
   el.state.entries[entryIndex].postPending = true;
   persist(el, {
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 
   Entry.create(entry).then(response => {
@@ -138,7 +138,7 @@ function createEntrySuccess (el, oldId, response){
 
   persist(el, {
     entry: Object.assign({}, el.state.entry),
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 };
 
@@ -146,7 +146,7 @@ function createEntryFailure (el, oldId, err){
   var entryIndex = findObjectIndexById(oldId, el.state.entries);
   delete el.state.entries[entryIndex].postPending;
   el.setState({
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
   console.log('createEntryFailure', err);
 };
@@ -167,7 +167,7 @@ function updateEntry (el, { entry, property, entryId }){
   el.state.entries[entryIndex].needsSync = true;
   persist(el, {
     entry: Object.assign({}, el.state.entries[entryIndex]),
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 
   Entry.update(entryId, entry).then(function(){
@@ -183,7 +183,7 @@ function updateEntrySuccess (el, id){
   delete entries[entryIndex].needsSync;
   persist(el, {
     entry: Object.assign({}, entries[entryIndex]),
-    setEntries: entries
+    entries: entries
   });
 };
 
@@ -208,7 +208,7 @@ function deleteEntry (el, { id }){
 
   persist(el, {
     entry: undefined,
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   }, function(){
     if(el.state.view !== '/entries') route('/entries', true);
   });
@@ -223,7 +223,7 @@ function deleteEntry (el, { id }){
 function deleteEntrySuccess (el, id){
   var entryIndex = findObjectIndexById(id, el.state.entries);
   persist(el, {
-    setEntries: removeObjectByIndex(entryIndex, el.state.entries)
+    entries: removeObjectByIndex(entryIndex, el.state.entries)
   });
 };
 
@@ -262,7 +262,7 @@ function newEntry (el){
 
   el.setState({
     entry: entry,
-    setEntries: [entry].concat(el.state.entries)
+    entries: [entry].concat(el.state.entries)
   }, function(){
     setEntry(el, {id: entry.id});
   });
@@ -273,7 +273,7 @@ function filterByText (el, text, e){
   let query = text === undefined ? e.target.value : text;
   if(el.state.filterText === query) return;
   if(!query) return el.setState({
-    setFilterText: ''
+    filterText: ''
   });
 
   // If the new query is a continuation of the prior query,
@@ -285,7 +285,7 @@ function filterByText (el, text, e){
     : el.state.entries;
 
   el.setState({
-    setFilterText: query
+    filterText: query
   });
 };
 

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -277,7 +277,7 @@ function filterByText (el, text, e){
   });
 
   el.setState({
-    filterText: query.toLowerCase()
+    filterText: query
   });
 };
 

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -276,16 +276,8 @@ function filterByText (el, text, e){
     filterText: ''
   });
 
-  // If the new query is a continuation of the prior query,
-  // fitler viewEntries for efficiency.
-  var q = query.toLowerCase();
-  var f = el.state.filterText;
-  var entries = (q.length > f.length && q.indexOf(f) === 0)
-    ? el.state.viewEntries
-    : el.state.entries;
-
   el.setState({
-    filterText: query
+    filterText: query.toLowerCase()
   });
 };
 

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -4,8 +4,8 @@ import { sortObjectsByDate, clearLocalStorage, getViewFromHref, applyFilters } f
 export default function getInitialState () {
   let loggedIn = !!cookie.get('logged_in');
   if(!loggedIn) clearLocalStorage();
-  let entries = JSON.parse(localStorage.getItem('entries')) || undefined;
-  if(entries) entries = sortObjectsByDate(entries);
+  let _filterText = '';
+  let _entries = JSON.parse(localStorage.getItem('entries')) || undefined;
 
   let state = {
     entryIndex: -1,
@@ -16,21 +16,25 @@ export default function getInitialState () {
     toastConfig: undefined,
     view: getViewFromHref(location.href),
     dark: localStorage.getItem('dark') === 'true',
-
-    filterText: '',
-    set setFilterText(filterText) {
-      this.filterText = filterText;
-      this.viewEntries = applyFilters(filterText, this.entries);
+    
+    get filterText() {
+      return _filterText;
+    },
+    set filterText(filterText) {
+      _filterText = filterText;
+      this.viewEntries = applyFilters(filterText, _entries);
     },
 
-    entries: [],
-    set setEntries(entries) {
-      this.entries = entries;
-      this.viewEntries = applyFilters(this.filterText, entries);
+    get entries() {
+      return _entries;
+    },
+    set entries(entries) {
+      _entries = entries;
+      this.viewEntries = applyFilters(_filterText, entries);
     }
   };
 
-  state.setEntries = entries;
+  state.entries = _entries;
 
   return state;
 };

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -35,6 +35,10 @@ export default function getInitialState () {
       return _entries;
     },
     set entries(entries) {
+      // Consider moving localStorage persistence to here
+      // and getting rid of persist.js altogether. But setters
+      // appear to be syncronous so that would lock the main
+      // thread unless I JSON.stringify in a worker.
       _entries = entries;
       this.viewEntries = applyFilters(_filterText, entries);
     }

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -21,6 +21,13 @@ export default function getInitialState () {
       return _filterText;
     },
     set filterText(filterText) {
+      // If the new query is a continuation of the prior query,
+      // fitler viewEntries for efficiency.
+      // var q = query.toLowerCase();
+      // var f = el.state.filterText;
+      // var entries = (q.length > f.length && q.indexOf(f) === 0)
+      //   ? el.state.viewEntries
+      //   : el.state.entries;
       _filterText = filterText;
       this.viewEntries = applyFilters(filterText, _entries);
     },

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -21,15 +21,14 @@ export default function getInitialState () {
       return _filterText;
     },
     set filterText(filterText) {
-      // If the new query is a continuation of the prior query,
+      // If the filterText is a continuation of _filterText,
       // fitler viewEntries for efficiency.
-      // var q = query.toLowerCase();
-      // var f = el.state.filterText;
-      // var entries = (q.length > f.length && q.indexOf(f) === 0)
-      //   ? el.state.viewEntries
-      //   : el.state.entries;
+      var list = (filterText.length > _filterText.length && filterText.indexOf(_filterText) === 0)
+        ? this.viewEntries
+        : _entries;
+
       _filterText = filterText;
-      this.viewEntries = applyFilters(filterText, _entries);
+      this.viewEntries = applyFilters(filterText, list);
     },
 
     get entries() {

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -1,27 +1,36 @@
 import cookie from '../cookie';
-import { sortObjectsByDate, filterHiddenEntries, clearLocalStorage, getViewFromHref } from '../utils';
+import { sortObjectsByDate, clearLocalStorage, getViewFromHref, applyFilters } from '../utils';
 
 export default function getInitialState () {
   let loggedIn = !!cookie.get('logged_in');
   if(!loggedIn) clearLocalStorage();
   let entries = JSON.parse(localStorage.getItem('entries')) || undefined;
   if(entries) entries = sortObjectsByDate(entries);
-  let viewEntries;
-  if(entries) viewEntries = filterHiddenEntries(entries);
 
   let state = {
-    scrollPosition: 0,
-    view: getViewFromHref(location.href),
-    showFilterInput: false,
-    filterText: '',
-    loggedIn: loggedIn,
-    entry: undefined,
     entryIndex: -1,
-    entries: entries,
-    viewEntries: viewEntries || entries,
+    entry: undefined,
+    scrollPosition: 0,
+    loggedIn: loggedIn,
+    showFilterInput: false,
     toastConfig: undefined,
-    dark: localStorage.getItem('dark') === 'true'
+    view: getViewFromHref(location.href),
+    dark: localStorage.getItem('dark') === 'true',
+
+    filterText: '',
+    set setFilterText(filterText) {
+      this.filterText = filterText;
+      this.viewEntries = applyFilters(filterText, this.entries);
+    },
+
+    entries: [],
+    set setEntries(entries) {
+      this.entries = entries;
+      this.viewEntries = applyFilters(this.filterText, entries);
+    }
   };
+
+  state.setEntries = entries;
 
   return state;
 };

--- a/client/js/persist/index.js
+++ b/client/js/persist/index.js
@@ -1,12 +1,6 @@
-import { sortObjectsByDate, applyFilters } from '../utils';
-
 export default function persist(el, state, cb) {
-  if(state.entries){
-    state.entries = sortObjectsByDate([].concat(state.entries));
-    state.viewEntries = applyFilters(el.state.filterText, state.entries);
-  }
   el.setState(state, cb);
-  if(state.entries){
-    localStorage.setItem('entries', JSON.stringify(state.entries));
+  if(state.setEntries){
+    localStorage.setItem('entries', JSON.stringify(state.setEntries));
   }
 }

--- a/client/js/persist/index.js
+++ b/client/js/persist/index.js
@@ -1,6 +1,6 @@
 export default function persist(el, state, cb) {
   el.setState(state, cb);
-  if(state.setEntries){
-    localStorage.setItem('entries', JSON.stringify(state.setEntries));
+  if(state.entries){
+    localStorage.setItem('entries', JSON.stringify(state.entries));
   }
 }

--- a/client/js/route-handlers/index.js
+++ b/client/js/route-handlers/index.js
@@ -29,7 +29,7 @@ function handleEntriesView (url) {
     let entry = this.state.entries[0];
     if(entry && entry.newEntry && !entry.text){
       this.setState({
-        entries: removeObjectByIndex(0, this.state.entries)
+        setEntries: removeObjectByIndex(0, this.state.entries)
       });
     }
   }

--- a/client/js/route-handlers/index.js
+++ b/client/js/route-handlers/index.js
@@ -29,7 +29,7 @@ function handleEntriesView (url) {
     let entry = this.state.entries[0];
     if(entry && entry.newEntry && !entry.text){
       this.setState({
-        setEntries: removeObjectByIndex(0, this.state.entries)
+        entries: removeObjectByIndex(0, this.state.entries)
       });
     }
   }

--- a/client/js/services/entry-service.js
+++ b/client/js/services/entry-service.js
@@ -28,5 +28,4 @@ function del (id) {
   });
 };
 
-
 export default { getAll, sync, create, update, del };

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -41,7 +41,8 @@ function filterHiddenEntries (entries) {
 
 function applyFilters (query = '', list = []) {
   list = filterHiddenEntries(list);
-  return filterObjectsByText(query, list);
+  list = filterObjectsByText(query, list);
+  return sortObjectsByDate(list);
 };
 
 function clearLocalStorage () {

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -39,7 +39,7 @@ function filterHiddenEntries (entries) {
   });
 };
 
-function applyFilters (query, list) {
+function applyFilters (query = '', list = []) {
   list = filterHiddenEntries(list);
   return filterObjectsByText(query, list);
 };

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -18,6 +18,7 @@ function sortObjectsByDate (list) {
 
 function filterObjectsByText (query, list) {
   if(!query) return list;
+  query = query.toLowerCase();
   return list.reduce(function(accumulator, obj){
     var index = obj.text.toLowerCase().indexOf(query);
     if(~index){


### PR DESCRIPTION
Not certain how I feel about this one, so I'm going to let it simmer for a bit.

### Reasons I like this

* It moves setting `viewEntries` from `persist.js` to `app-state.js` by creating setter functions for `filterText` and `entries`.
* It's declarative so far as state initialization goes.
* Between the three solutions I've some up with so far (setting in `persist.js`, the `computed-properties` branch, and this one), it's possibly the cleanest solution.

### Reasons I don't like this

* It makes certain `setState` calls less declarative.
* It adds a small amount of "magic" to the app which is generally bad.
* Computed properties in Polymer, Vue, Svelte, and others list the properties upon which they depend. This means that if `a` depends on `b` and `c`, `a` defines that relationship while `b` and `c` go on knowing nothing about `a`. Following this example, using setters for computed properties requires that both `b` and `c` know about `a`, know about `a`'s other dependent props, _and_ provide itself and those other dependent properties to a function call that will update `a` as needed. This feels wrong.