### PR TITLE
Computed properties via getters

### DIFF
--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -42,12 +42,14 @@ export default class App extends Component {
   }
 
   render(props, state) {
+    // Save this off since it triggers a getter computation
+    let viewEntries = state.viewEntries;
     return (
       <div class={!!state.dark ? 'app dark' : 'app'}>
         <Header
           view={state.view}
           loggedIn={state.loggedIn}
-          viewEntries={state.viewEntries}
+          viewEntries={viewEntries}
           entry={state.entry}
           filterText={state.filterText}
           showFilterInput={state.showFilterInput}
@@ -58,12 +60,12 @@ export default class App extends Component {
             <Entries path="/entries"
               scrollPosition={state.scrollPosition}
               loggedIn={state.loggedIn}
-              entries={state.viewEntries}/>
+              viewEntries={viewEntries}/>
             <Entry path="/entry/:id"
               loggedIn={state.loggedIn}
               view={state.view}
               entry={state.entry}
-              viewEntries={state.viewEntries}
+              viewEntries={viewEntries}
               entryIndex={state.entryIndex}/>
           </Router>
           <Toast config={state.toastConfig}/>

--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -20,7 +20,7 @@ export default class Entries extends Component {
     entries = entries || [];
     if(!entries.length){
       return (
-        <h2 class="center-text">It's empty in here!</h2>
+        <h2 class="center-text fly">It's empty in here!</h2>
       );
     }
     return (

--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -11,21 +11,21 @@ export default class Entries extends Component {
 
   shouldComponentUpdate(np) {
     let op = this.props;
-    return op.entries !== np.entries
+    return op.viewEntries !== np.viewEntries
       || op.scrollPosition === np.scrollPosition;
   }
 
-  render({ entries, scrollPosition }) {
+  render({ viewEntries, scrollPosition }) {
     document.body.scrollTop = scrollPosition;
-    entries = entries || [];
-    if(!entries.length){
+    viewEntries = viewEntries || [];
+    if(!viewEntries.length){
       return (
         <h2 class="center-text fly">It's empty in here!</h2>
       );
     }
     return (
       <ScrollViewport class="entry-list fly" rowHeight={84} overscan={20}>
-        {entries.map(entry => <EntryPreview entry={entry}/>)}
+        {viewEntries.map(entry => <EntryPreview entry={entry}/>)}
       </ScrollViewport>
     );
   }

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -28,7 +28,7 @@ function getAllEntries (el){
 
 function getAllEntriesSuccess (el, response){
   persist(el, {
-    setEntries: response.entries,
+    entries: response.entries,
   }, function(){
     localStorage.setItem('timestamp', response.timestamp);
   });
@@ -89,7 +89,7 @@ function applySyncPatch (el, entries){
 
 function persistSyncPatch (el, timestamp){
   persist(el, {
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   }, function(){
     if(el.state.view === '/entry' && el.state.entryId){
       setEntry(el, {id: el.state.entryId});
@@ -108,14 +108,14 @@ function createEntry (el, { entry, clientSync }){
 
   persist(el, {
     entry: entry,
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 
   if(!clientSync && entry.postPending) return;
 
   el.state.entries[entryIndex].postPending = true;
   persist(el, {
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 
   Entry.create(entry).then(response => {
@@ -138,7 +138,7 @@ function createEntrySuccess (el, oldId, response){
 
   persist(el, {
     entry: Object.assign({}, el.state.entry),
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 };
 
@@ -146,7 +146,7 @@ function createEntryFailure (el, oldId, err){
   var entryIndex = findObjectIndexById(oldId, el.state.entries);
   delete el.state.entries[entryIndex].postPending;
   el.setState({
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
   console.log('createEntryFailure', err);
 };
@@ -167,7 +167,7 @@ function updateEntry (el, { entry, property, entryId }){
   el.state.entries[entryIndex].needsSync = true;
   persist(el, {
     entry: Object.assign({}, el.state.entries[entryIndex]),
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   });
 
   Entry.update(entryId, entry).then(function(){
@@ -183,7 +183,7 @@ function updateEntrySuccess (el, id){
   delete entries[entryIndex].needsSync;
   persist(el, {
     entry: Object.assign({}, entries[entryIndex]),
-    setEntries: entries
+    entries: entries
   });
 };
 
@@ -208,7 +208,7 @@ function deleteEntry (el, { id }){
 
   persist(el, {
     entry: undefined,
-    setEntries: [].concat(el.state.entries)
+    entries: [].concat(el.state.entries)
   }, function(){
     if(el.state.view !== '/entries') route('/entries', true);
   });
@@ -223,7 +223,7 @@ function deleteEntry (el, { id }){
 function deleteEntrySuccess (el, id){
   var entryIndex = findObjectIndexById(id, el.state.entries);
   persist(el, {
-    setEntries: removeObjectByIndex(entryIndex, el.state.entries)
+    entries: removeObjectByIndex(entryIndex, el.state.entries)
   });
 };
 
@@ -262,7 +262,7 @@ function newEntry (el){
 
   el.setState({
     entry: entry,
-    setEntries: [entry].concat(el.state.entries)
+    entries: [entry].concat(el.state.entries)
   }, function(){
     setEntry(el, {id: entry.id});
   });
@@ -273,7 +273,7 @@ function filterByText (el, text, e){
   let query = text === undefined ? e.target.value : text;
   if(el.state.filterText === query) return;
   if(!query) return el.setState({
-    setFilterText: ''
+    filterText: ''
   });
 
   // If the new query is a continuation of the prior query,
@@ -285,7 +285,7 @@ function filterByText (el, text, e){
     : el.state.entries;
 
   el.setState({
-    setFilterText: query
+    filterText: query
   });
 };
 

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -277,7 +277,7 @@ function filterByText (el, text, e){
   });
 
   el.setState({
-    filterText: query.toLowerCase()
+    filterText: query
   });
 };
 

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -276,16 +276,8 @@ function filterByText (el, text, e){
     filterText: ''
   });
 
-  // If the new query is a continuation of the prior query,
-  // fitler viewEntries for efficiency.
-  var q = query.toLowerCase();
-  var f = el.state.filterText;
-  var entries = (q.length > f.length && q.indexOf(f) === 0)
-    ? el.state.viewEntries
-    : el.state.entries;
-
   el.setState({
-    filterText: query
+    filterText: query.toLowerCase()
   });
 };
 

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -4,8 +4,8 @@ import { sortObjectsByDate, clearLocalStorage, getViewFromHref, applyFilters } f
 export default function getInitialState () {
   let loggedIn = !!cookie.get('logged_in');
   if(!loggedIn) clearLocalStorage();
-  let entries = JSON.parse(localStorage.getItem('entries')) || undefined;
-  if(entries) entries = sortObjectsByDate(entries);
+  let _filterText = '';
+  let _entries = JSON.parse(localStorage.getItem('entries')) || undefined;
 
   let state = {
     entryIndex: -1,
@@ -16,21 +16,25 @@ export default function getInitialState () {
     toastConfig: undefined,
     view: getViewFromHref(location.href),
     dark: localStorage.getItem('dark') === 'true',
-
-    filterText: '',
-    set setFilterText(filterText) {
-      this.filterText = filterText;
-      this.viewEntries = applyFilters(filterText, this.entries);
+    
+    get filterText() {
+      return _filterText;
+    },
+    set filterText(filterText) {
+      _filterText = filterText;
+      this.viewEntries = applyFilters(filterText, _entries);
     },
 
-    entries: [],
-    set setEntries(entries) {
-      this.entries = entries;
-      this.viewEntries = applyFilters(this.filterText, entries);
+    get entries() {
+      return _entries;
+    },
+    set entries(entries) {
+      _entries = entries;
+      this.viewEntries = applyFilters(_filterText, entries);
     }
   };
 
-  state.setEntries = entries;
+  state.entries = _entries;
 
   return state;
 };

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -17,12 +17,8 @@ export default function getInitialState () {
     toastConfig: undefined,
     view: getViewFromHref(location.href),
     dark: localStorage.getItem('dark') === 'true',
-    set viewEntries(_) { return console.warn('Attempted to set computed property viewEntries.'); },
-    get viewEntries() {
-      return this.filterText
-        ? applyFilters(this.filterText, this.entries)
-        : this.entries;
-    }
+    get viewEntries() { return applyFilters(this.filterText, this.entries); },
+    set viewEntries() { return console.warn('Attempted to set computed property viewEntries.'); }
   };
 
   return state;

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -19,7 +19,6 @@ export default function getInitialState () {
     dark: localStorage.getItem('dark') === 'true',
     set viewEntries(_) { return; },
     get viewEntries() {
-      console.log('called')
       return this.filterText
         ? applyFilters(this.filterText, this.entries)
         : this.entries;

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -17,7 +17,7 @@ export default function getInitialState () {
     toastConfig: undefined,
     view: getViewFromHref(location.href),
     dark: localStorage.getItem('dark') === 'true',
-    set viewEntries(_) { return; },
+    set viewEntries(_) { return console.warn('Attempted to set computed property viewEntries.'); },
     get viewEntries() {
       return this.filterText
         ? applyFilters(this.filterText, this.entries)

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -35,6 +35,10 @@ export default function getInitialState () {
       return _entries;
     },
     set entries(entries) {
+      // Consider moving localStorage persistence to here
+      // and getting rid of persist.js altogether. But setters
+      // appear to be syncronous so that would lock the main
+      // thread unless I JSON.stringify in a worker.
       _entries = entries;
       this.viewEntries = applyFilters(_filterText, entries);
     }

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -17,7 +17,7 @@ export default function getInitialState () {
     dark: localStorage.getItem('dark') === 'true',
     entries: JSON.parse(localStorage.getItem('entries')) || undefined,
     get viewEntries() { return applyFilters(this.filterText, this.entries); },
-    set viewEntries() { return console.warn('Attempted to set computed property viewEntries.'); }
+    set viewEntries(_) { return console.warn('Attempted to set computed property viewEntries.'); }
   };
 
   return state;

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -21,6 +21,13 @@ export default function getInitialState () {
       return _filterText;
     },
     set filterText(filterText) {
+      // If the new query is a continuation of the prior query,
+      // fitler viewEntries for efficiency.
+      // var q = query.toLowerCase();
+      // var f = el.state.filterText;
+      // var entries = (q.length > f.length && q.indexOf(f) === 0)
+      //   ? el.state.viewEntries
+      //   : el.state.entries;
       _filterText = filterText;
       this.viewEntries = applyFilters(filterText, _entries);
     },

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -21,15 +21,14 @@ export default function getInitialState () {
       return _filterText;
     },
     set filterText(filterText) {
-      // If the new query is a continuation of the prior query,
+      // If the filterText is a continuation of _filterText,
       // fitler viewEntries for efficiency.
-      // var q = query.toLowerCase();
-      // var f = el.state.filterText;
-      // var entries = (q.length > f.length && q.indexOf(f) === 0)
-      //   ? el.state.viewEntries
-      //   : el.state.entries;
+      var list = (filterText.length > _filterText.length && filterText.indexOf(_filterText) === 0)
+        ? this.viewEntries
+        : _entries;
+
       _filterText = filterText;
-      this.viewEntries = applyFilters(filterText, _entries);
+      this.viewEntries = applyFilters(filterText, list);
     },
 
     get entries() {

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -1,27 +1,36 @@
 import cookie from '../cookie';
-import { sortObjectsByDate, filterHiddenEntries, clearLocalStorage, getViewFromHref } from '../utils';
+import { sortObjectsByDate, clearLocalStorage, getViewFromHref, applyFilters } from '../utils';
 
 export default function getInitialState () {
   let loggedIn = !!cookie.get('logged_in');
   if(!loggedIn) clearLocalStorage();
   let entries = JSON.parse(localStorage.getItem('entries')) || undefined;
   if(entries) entries = sortObjectsByDate(entries);
-  let viewEntries;
-  if(entries) viewEntries = filterHiddenEntries(entries);
 
   let state = {
-    scrollPosition: 0,
-    view: getViewFromHref(location.href),
-    showFilterInput: false,
-    filterText: '',
-    loggedIn: loggedIn,
-    entry: undefined,
     entryIndex: -1,
-    entries: entries,
-    viewEntries: viewEntries || entries,
+    entry: undefined,
+    scrollPosition: 0,
+    loggedIn: loggedIn,
+    showFilterInput: false,
     toastConfig: undefined,
-    dark: localStorage.getItem('dark') === 'true'
+    view: getViewFromHref(location.href),
+    dark: localStorage.getItem('dark') === 'true',
+
+    filterText: '',
+    set setFilterText(filterText) {
+      this.filterText = filterText;
+      this.viewEntries = applyFilters(filterText, this.entries);
+    },
+
+    entries: [],
+    set setEntries(entries) {
+      this.entries = entries;
+      this.viewEntries = applyFilters(this.filterText, entries);
+    }
   };
+
+  state.setEntries = entries;
 
   return state;
 };

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -4,12 +4,10 @@ import { clearLocalStorage, getViewFromHref, applyFilters } from '../utils';
 export default function getInitialState () {
   let loggedIn = !!cookie.get('logged_in');
   if(!loggedIn) clearLocalStorage();
-  let entries = JSON.parse(localStorage.getItem('entries')) || undefined;
 
   let state = {
     entryIndex: -1,
     filterText: '',
-    entries: entries,
     entry: undefined,
     scrollPosition: 0,
     loggedIn: loggedIn,
@@ -17,6 +15,7 @@ export default function getInitialState () {
     toastConfig: undefined,
     view: getViewFromHref(location.href),
     dark: localStorage.getItem('dark') === 'true',
+    entries: JSON.parse(localStorage.getItem('entries')) || undefined,
     get viewEntries() { return applyFilters(this.filterText, this.entries); },
     set viewEntries() { return console.warn('Attempted to set computed property viewEntries.'); }
   };

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -1,14 +1,15 @@
 import cookie from '../cookie';
-import { sortObjectsByDate, clearLocalStorage, getViewFromHref, applyFilters } from '../utils';
+import { clearLocalStorage, getViewFromHref, applyFilters } from '../utils';
 
 export default function getInitialState () {
   let loggedIn = !!cookie.get('logged_in');
   if(!loggedIn) clearLocalStorage();
-  let _filterText = '';
-  let _entries = JSON.parse(localStorage.getItem('entries')) || undefined;
+  let entries = JSON.parse(localStorage.getItem('entries')) || undefined;
 
   let state = {
     entryIndex: -1,
+    filterText: '',
+    entries: entries,
     entry: undefined,
     scrollPosition: 0,
     loggedIn: loggedIn,
@@ -16,35 +17,14 @@ export default function getInitialState () {
     toastConfig: undefined,
     view: getViewFromHref(location.href),
     dark: localStorage.getItem('dark') === 'true',
-    
-    get filterText() {
-      return _filterText;
-    },
-    set filterText(filterText) {
-      // If the filterText is a continuation of _filterText,
-      // fitler viewEntries for efficiency.
-      var list = (filterText.length > _filterText.length && filterText.indexOf(_filterText) === 0)
-        ? this.viewEntries
-        : _entries;
-
-      _filterText = filterText;
-      this.viewEntries = applyFilters(filterText, list);
-    },
-
-    get entries() {
-      return _entries;
-    },
-    set entries(entries) {
-      // Consider moving localStorage persistence to here
-      // and getting rid of persist.js altogether. But setters
-      // appear to be syncronous so that would lock the main
-      // thread unless I JSON.stringify in a worker.
-      _entries = entries;
-      this.viewEntries = applyFilters(_filterText, entries);
+    set viewEntries(_) { return; },
+    get viewEntries() {
+      console.log('called')
+      return this.filterText
+        ? applyFilters(this.filterText, this.entries)
+        : this.entries;
     }
   };
-
-  state.entries = _entries;
 
   return state;
 };

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -17,7 +17,7 @@ export default function getInitialState () {
     dark: localStorage.getItem('dark') === 'true',
     entries: JSON.parse(localStorage.getItem('entries')) || undefined,
     get viewEntries() { return applyFilters(this.filterText, this.entries); },
-    set viewEntries(_) { return console.warn('Attempted to set computed property viewEntries.'); }
+    set viewEntries(_) { return; }
   };
 
   return state;

--- a/client/js/persist/index.js
+++ b/client/js/persist/index.js
@@ -1,12 +1,6 @@
-import { sortObjectsByDate, applyFilters } from '../utils';
-
 export default function persist(el, state, cb) {
-  if(state.entries){
-    state.entries = sortObjectsByDate([].concat(state.entries));
-    state.viewEntries = applyFilters(el.state.filterText, state.entries);
-  }
   el.setState(state, cb);
-  if(state.entries){
-    localStorage.setItem('entries', JSON.stringify(state.entries));
+  if(state.setEntries){
+    localStorage.setItem('entries', JSON.stringify(state.setEntries));
   }
 }

--- a/client/js/persist/index.js
+++ b/client/js/persist/index.js
@@ -1,6 +1,6 @@
 export default function persist(el, state, cb) {
   el.setState(state, cb);
-  if(state.setEntries){
-    localStorage.setItem('entries', JSON.stringify(state.setEntries));
+  if(state.entries){
+    localStorage.setItem('entries', JSON.stringify(state.entries));
   }
 }

--- a/client/js/route-handlers/index.js
+++ b/client/js/route-handlers/index.js
@@ -29,7 +29,7 @@ function handleEntriesView (url) {
     let entry = this.state.entries[0];
     if(entry && entry.newEntry && !entry.text){
       this.setState({
-        entries: removeObjectByIndex(0, this.state.entries)
+        setEntries: removeObjectByIndex(0, this.state.entries)
       });
     }
   }

--- a/client/js/route-handlers/index.js
+++ b/client/js/route-handlers/index.js
@@ -29,7 +29,7 @@ function handleEntriesView (url) {
     let entry = this.state.entries[0];
     if(entry && entry.newEntry && !entry.text){
       this.setState({
-        setEntries: removeObjectByIndex(0, this.state.entries)
+        entries: removeObjectByIndex(0, this.state.entries)
       });
     }
   }

--- a/client/js/services/entry-service.js
+++ b/client/js/services/entry-service.js
@@ -28,5 +28,4 @@ function del (id) {
   });
 };
 
-
 export default { getAll, sync, create, update, del };

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -41,7 +41,8 @@ function filterHiddenEntries (entries) {
 
 function applyFilters (query = '', list = []) {
   list = filterHiddenEntries(list);
-  return filterObjectsByText(query, list);
+  list = filterObjectsByText(query, list);
+  return sortObjectsByDate(list);
 };
 
 function clearLocalStorage () {

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -39,7 +39,7 @@ function filterHiddenEntries (entries) {
   });
 };
 
-function applyFilters (query, list) {
+function applyFilters (query = '', list = []) {
   list = filterHiddenEntries(list);
   return filterObjectsByText(query, list);
 };

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -18,6 +18,7 @@ function sortObjectsByDate (list) {
 
 function filterObjectsByText (query, list) {
   if(!query) return list;
+  query = query.toLowerCase();
   return list.reduce(function(accumulator, obj){
     var index = obj.text.toLowerCase().indexOf(query);
     if(~index){


### PR DESCRIPTION
Another alternative to #25 

### The good

* This is the simplest solution to computed properties. Simply allow a getter for the computed property to compute said property on each get.
* It's declarative, simple, and native.

### The bad

* A solution this simple means that I'm calculating `viewEntries` every time I call `setState`, regardless of what I updated. That means every time I scroll on the entries page; every time I click a link or switch between entries; every time I click the magnifying glass icon the `viewEntries` setter executes relatively expensive functionality. Even when it's not necessary. This is horrifically inefficient.
* A solution this simple prevents me from having the `filterText` optimization I have in production right now. The optimization filters `viewEntries` rather than `entries` if the new `filterText` is a continuation of the prior `filterText`.