### PR TITLE
Adapting to preact's unintentionally breaking feature release.

### DIFF
--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -14,6 +14,7 @@ import fire from '../../js/fire';
 import handleRouteChange from '../../js/route-handlers';
 import swipe from '../../js/swipe';
 import arrow from '../../js/arrow';
+import { merge } from '../../js/utils';
 
 // Make sure new pages are always scrolled to the top
 // while history entries maintain their scroll position.
@@ -25,6 +26,7 @@ history.pushState = (a, b, url) => {
 
 export default class App extends Component {
   state = getInitialState();
+  realState = getInitialState();
   
   componentWillMount() {
     freedux(this, actions);
@@ -40,6 +42,12 @@ export default class App extends Component {
 
   componentWillUpdate() {
     fire('getEntries')();
+  }
+
+  set(delta, cb) {
+    merge(this.realState, delta);
+    this.setState(this.realState, cb);
+    this.state = this.realState;
   }
 
   render(props, state) {

--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -68,7 +68,7 @@ export default class App extends Component {
             <Login path="/"/>
             <Entries path="/entries"
               scrollPosition={state.scrollPosition}
-              entries={state.viewEntries}/>
+              viewEntries={state.viewEntries}/>
             <Entry path="/entry/:id"
               view={state.view}
               entry={state.entry}

--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -25,8 +25,7 @@ history.pushState = (a, b, url) => {
 };
 
 export default class App extends Component {
-  state = getInitialState();
-  realState = getInitialState();
+  realState = this.state = getInitialState();
   
   componentWillMount() {
     freedux(this, actions);

--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -7,7 +7,7 @@ import debounce from '../../js/debounce';
 export default class Entries extends Component {
   componentDidMount() {
     document.body.onscroll = debounce(() => {
-      fire('scrollBody', {scrollPosition: document.body.scrollTop})();
+      fire('linkstate', {key: 'scrollPosition', val: document.body.scrollTop})();
     }, 50);
   }
 

--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -17,21 +17,21 @@ export default class Entries extends Component {
 
   shouldComponentUpdate(np) {
     let op = this.props;
-    return op.entries !== np.entries
+    return op.viewEntries !== np.viewEntries
       || op.scrollPosition === np.scrollPosition;
   }
 
-  render({ entries, scrollPosition }) {
+  render({ viewEntries, scrollPosition }) {
     document.body.scrollTop = scrollPosition;
-    entries = entries || [];
-    if(!entries.length){
+    viewEntries = viewEntries || [];
+    if(!viewEntries.length){
       return (
         <h2 class="center-text">It's empty in here!</h2>
       );
     }
     return (
       <ScrollViewport class="entry-list fade-down" rowHeight={84} overscan={20}>
-        {entries.map(entry => <EntryPreview entry={entry}/>)}
+        {viewEntries.map(entry => <EntryPreview entry={entry}/>)}
       </ScrollViewport>
     );
   }

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -1,5 +1,5 @@
 import Entry from '../services/entry-service';
-import { findObjectIndexById, removeObjectByIndex, applyFilters } from '../utils';
+import { findObjectIndexById, removeObjectByIndex } from '../utils';
 import { route } from '../../components/router';
 
 let dataFetched = false;

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -25,7 +25,7 @@ function getAllEntries (el){
 };
 
 function getAllEntriesSuccess (el, response){
-  el.setState({
+  el.set({
     entries: response.entries,
     timestamp: response.timestamp
   });
@@ -84,7 +84,7 @@ function applySyncPatch (el, entries){
 };
 
 function persistSyncPatch (el, timestamp){
-  el.setState({
+  el.set({
     entries: [].concat(el.state.entries),
     timestamp: response.timestamp
   }, () => {
@@ -102,7 +102,7 @@ function createEntry (el, { entry, clientSync }){
   var entryIndex = findObjectIndexById(entry.id, el.state.entries);
   el.state.entries[entryIndex] = entry;
 
-  el.setState({
+  el.set({
     entry: entry,
     entries: [].concat(el.state.entries)
   });
@@ -110,7 +110,7 @@ function createEntry (el, { entry, clientSync }){
   if(!clientSync && entry.postPending) return;
 
   el.state.entries[entryIndex].postPending = true;
-  el.setState({ entries: [].concat(el.state.entries) });
+  el.set({ entries: [].concat(el.state.entries) });
 
   Entry.create(entry).then(response => {
     createEntrySuccess(el, entry.id, response);
@@ -130,7 +130,7 @@ function createEntrySuccess (el, oldId, response){
   delete el.state.entries[entryIndex].newEntry;
   delete el.state.entries[entryIndex].needsSync;
 
-  el.setState({
+  el.set({
     entry: Object.assign({}, el.state.entry),
     entries: [].concat(el.state.entries)
   });
@@ -139,7 +139,7 @@ function createEntrySuccess (el, oldId, response){
 function createEntryFailure (el, oldId, err){
   var entryIndex = findObjectIndexById(oldId, el.state.entries);
   delete el.state.entries[entryIndex].postPending;
-  el.setState({
+  el.set({
     entries: [].concat(el.state.entries)
   });
   console.log('createEntryFailure', err);
@@ -159,7 +159,7 @@ function updateEntry (el, { entry, property, entryId }){
 
   el.state.entries[entryIndex][property] = entry[property];
   el.state.entries[entryIndex].needsSync = true;
-  el.setState({
+  el.set({
     entry: Object.assign({}, el.state.entries[entryIndex]),
     entries: [].concat(el.state.entries)
   });
@@ -175,7 +175,7 @@ function updateEntrySuccess (el, id){
   let entries = [].concat(el.state.entries);
   var entryIndex = findObjectIndexById(id, entries);
   delete entries[entryIndex].needsSync;
-  el.setState({
+  el.set({
     entry: Object.assign({}, entries[entryIndex]),
     entries: entries
   });
@@ -200,7 +200,7 @@ function deleteEntry (el, { id }){
   el.state.entries[entryIndex].needsSync = true;
   el.state.entries[entryIndex].deleted = true;
 
-  el.setState({
+  el.set({
     entry: undefined,
     entries: [].concat(el.state.entries)
   }, () => {
@@ -216,7 +216,7 @@ function deleteEntry (el, { id }){
 
 function deleteEntrySuccess (el, id){
   var entryIndex = findObjectIndexById(id, el.state.entries);
-  el.setState({ entries: removeObjectByIndex(entryIndex, el.state.entries) });
+  el.set({ entries: removeObjectByIndex(entryIndex, el.state.entries) });
 };
 
 function deleteEntryFailure (el, err){
@@ -237,7 +237,7 @@ function setEntry (el, { id }){
   var entryIndex = findObjectIndexById(parseInt(id), el.state[collection]);
   var entry = el.state[collection][entryIndex];
 
-  el.setState({
+  el.set({
     entry: entry,
     entryIndex: entryIndex
   });
@@ -252,7 +252,7 @@ function newEntry (el){
     newEntry: true
   };
 
-  el.setState({
+  el.set({
     entry: entry,
     entries: [entry].concat(el.state.entries)
   }, function(){
@@ -265,12 +265,12 @@ function filterByText (el, text, e){
   let query = text === undefined ? e.target.value : text;
   if(el.state.filterText === query) return;
   let filterText = query || '';
-  el.setState({ filterText });
+  el.set({ filterText });
 };
 
 function blurTextFilter (el){
   if(!el.state.filterText){
-    el.setState({showFilterInput: false});
+    el.set({showFilterInput: false});
   }
 };
 

--- a/client/js/actions/global-actions.js
+++ b/client/js/actions/global-actions.js
@@ -1,12 +1,12 @@
 function linkstate (el, { key, val, cb }){
   let obj = {};
   obj[key] = val;
-  el.setState(obj, cb);
+  el.set(obj, cb);
 };
 
 // I tried replacing this with a linkstate call, but it didn't work.
 function scrollBody (el, { scrollPosition }){
-  el.setState({scrollPosition});
+  el.set({scrollPosition});
 };
 
 export default {

--- a/client/js/actions/global-actions.js
+++ b/client/js/actions/global-actions.js
@@ -4,12 +4,6 @@ function linkstate (el, { key, val, cb }){
   el.set(obj, cb);
 };
 
-// I tried replacing this with a linkstate call, but it didn't work.
-function scrollBody (el, { scrollPosition }){
-  el.set({scrollPosition});
-};
-
 export default {
-  linkstate,
-  scrollBody
+  linkstate
 };

--- a/client/js/actions/user-actions.js
+++ b/client/js/actions/user-actions.js
@@ -13,7 +13,7 @@ function login (el, user){
 };
 
 function loginSuccess (el, user){
-  el.setState({
+  el.set({
     loggedIn: true,
   }, function(){
     route('/entries', true);

--- a/client/js/actions/user-actions.js
+++ b/client/js/actions/user-actions.js
@@ -47,7 +47,7 @@ function logout (el){
 
 function logoutSuccess (el){
   clearLocalStorage();
-  el.state = getInitialState();
+  el.realState = el.state = getInitialState();
   route('/');
 };
 

--- a/client/js/route-handlers/index.js
+++ b/client/js/route-handlers/index.js
@@ -5,7 +5,7 @@ import { route } from '../../components/router';
 export default function handleRouteChange (url) {
   let view = getViewFromHref(url);
   if(view !== '/' && !this.state.loggedIn) route('/', true);
-  this.setState({view: view});
+  this.set({view: view});
   handleRoute.call(this, view, url);
   if(this.state.toastConfig) fire('linkstate', {key: 'toastConfig'})();
 };
@@ -28,7 +28,7 @@ function handleEntriesView (url) {
   if(Array.isArray(this.state.entries)){
     let entry = this.state.entries[0];
     if(entry && entry.newEntry && !entry.text){
-      this.setState({
+      this.set({
         entries: removeObjectByIndex(0, this.state.entries)
       });
     }

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -34,7 +34,7 @@ function filterObjectsByText (query, list) {
   }, []);
 };
 
-function filterHiddenEntries (entries) {
+function filterHiddenEntries (entries = []) {
   return entries.filter(function(entry){
     return !entry.deleted;
   });
@@ -59,6 +59,11 @@ function getViewFromHref (href) {
     : href;
 };
 
+function merge (obj, props) {
+	for (let i in props) obj[i] = props[i];
+	return obj;
+};
+
 export {
   findObjectIndexById,
   removeObjectByIndex,
@@ -67,5 +72,6 @@ export {
   filterHiddenEntries,
   applyFilters,
   clearLocalStorage,
-  getViewFromHref
+  getViewFromHref,
+  merge
 };

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -60,8 +60,8 @@ function getViewFromHref (href) {
 };
 
 function merge (obj, props) {
-	for (let i in props) obj[i] = props[i];
-	return obj;
+  for (let i in props) obj[i] = props[i];
+  return obj;
 };
 
 export {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8539,9 +8539,9 @@
       }
     },
     "preact": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-8.2.5.tgz",
-      "integrity": "sha1-y/o5YqgBJ2gVn20B1G+cHrMhPAo="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-8.3.1.tgz",
+      "integrity": "sha512-s8H1Y8O9e+mOBo3UP1jvWqArPmjCba2lrrGLlq/0kN1XuIINUbYtf97iiXKxCuG3eYwmppPKnyW2DBrNj/TuTg=="
     },
     "preact-scroll-viewport": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsonwebtoken": "5.5.4",
     "mysql": "2.5.5",
     "nodemon": "1.8.1",
-    "preact": "8.2.5",
+    "preact": "^8.3.1",
     "preact-scroll-viewport": "^0.2.0",
     "select": "^1.1.2",
     "sequelize": "3.19.3",

--- a/server/models/entry-model.js
+++ b/server/models/entry-model.js
@@ -4,7 +4,6 @@ module.exports = function(sequelize, Sequelize){
     ownerId: {type: Sequelize.INTEGER(11), field: 'owner_id'},
     date: Sequelize.DATE,
     text: Sequelize.TEXT,
-    isPublic: {type: Sequelize.BOOLEAN, field: 'is_public'},
     updatedAt: {type: Sequelize.INTEGER(15), field: 'updated_at'},
     deleted: Sequelize.BOOLEAN,
     deviceId: {type: Sequelize.STRING(5), field: 'device_id'},

--- a/server/services/entry-service.js
+++ b/server/services/entry-service.js
@@ -44,7 +44,7 @@ module.exports = function(Entry, sequelize){
     return Entry.findOne({
       where: {id: id},
       attributes: [
-        'id', 'ownerId', 'text', 'isPublic',
+        'id', 'ownerId', 'text',
         [sequelize.fn('date_format', sequelize.col('date'), '%Y-%m-%d'), 'date'],
       ],
       raw: true
@@ -57,7 +57,6 @@ module.exports = function(Entry, sequelize){
         ownerId: ownerId,
         date: data.date,
         text: data.text,
-        isPublic: 0,
         updatedAt: date.getUtcZeroTimestamp(),
         deviceId: deviceId
       }).then(function (entry){
@@ -69,7 +68,6 @@ module.exports = function(Entry, sequelize){
   }
 
   self.updateEntry = function(entryId, data, deviceId){
-    data.isPublic = 0;
     data.updatedAt = date.getUtcZeroTimestamp();
     data.deviceId = deviceId;
 
@@ -81,7 +79,6 @@ module.exports = function(Entry, sequelize){
   self.deleteEntry = function(entryId, deviceId){
     var data = {
       text: '',
-      isPublic: 0,
       deleted: 1,
       updatedAt: date.getUtcZeroTimestamp(),
       deviceId: deviceId


### PR DESCRIPTION
Since `8.3.0`, preact overwrites the state object's reference on every `setState` call. Since my state object is a proxy that handles local persistence and computed properties, this breaks my app. This PR fixes the issue by wrapping the `setState` method with my own `set` method that restores `this.state` after calling `setState`.