### PR TITLE
Product hardening

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,11 +11,13 @@ var express = require('express'),
   AES = require('./server/utils/aes'),
   PORT = process.env.PORT || 3000;
 
-// Keep the dyno awake
-var http = require('http');
-setInterval(function() {
-  http.get('https://preact-journal.herokuapp.com');
-}, 900000); // Every 15 minutes
+// Keep the dyno awake when in production
+if(process.env.NODE_ENV === 'production'){
+  var https = require('http');
+  setInterval(function() {
+    https.get('https://preact-journal.herokuapp.com');
+  }, 900000); // Every 15 minutes
+}
 
 app.disable('x-powered-by');
 app.use(forceSsl);

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -1,5 +1,5 @@
 import Entry from '../services/entry-service';
-import { findObjectIndexById, removeObjectByIndex, isActiveEntry } from '../utils';
+import { findObjectIndexById, removeObjectByIndex, isActiveEntryId } from '../utils';
 import { route } from '../../components/router';
 
 let dataFetched = false;
@@ -161,7 +161,7 @@ function createEntrySuccess (el, oldId, response){
    * Only update state.entry if the entry we just
    * modified is still active.
    */
-  if(isActiveEntry(el, oldId)) el.state.entry.id = response.id;
+  if(isActiveEntryId(el, oldId)) el.state.entry.id = response.id;
 
   el.state.entries[entryIndex].id = response.id;
   delete el.state.entries[entryIndex].postPending;
@@ -196,7 +196,7 @@ function createEntryFailure (el, oldId, err){
    * Only update state.entry if the entry we just
    * modified is still active.
    */
-  if(isActiveEntry(el, oldId)) delete el.state.entry.postPending;
+  if(isActiveEntryId(el, oldId)) delete el.state.entry.postPending;
 
   var entryIndex = findObjectIndexById(oldId, el.state.entries);
   delete el.state.entries[entryIndex].postPending;
@@ -243,7 +243,7 @@ function updateEntrySuccess (el, id){
    * Only update state.entry if the entry we just
    * modified is still active.
    */
-  const entry = isActiveEntry(el, id)
+  const entry = isActiveEntryId(el, id)
     ? Object.assign({}, entries[entryIndex])
     : el.state.entry;
 

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -64,6 +64,11 @@ function merge (obj, props) {
   return obj;
 };
 
+function isActiveEntry (el, id) {
+  if(!el.state.entry) return false;
+  return el.state.entry.id === id;
+};
+
 export {
   findObjectIndexById,
   removeObjectByIndex,
@@ -73,5 +78,6 @@ export {
   applyFilters,
   clearLocalStorage,
   getViewFromHref,
-  merge
+  merge,
+  isActiveEntry
 };

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -64,7 +64,7 @@ function merge (obj, props) {
   return obj;
 };
 
-function isActiveEntry (el, id) {
+function isActiveEntryId (el, id) {
   if(!el.state.entry) return false;
   return el.state.entry.id === id;
 };
@@ -79,5 +79,5 @@ export {
   clearLocalStorage,
   getViewFromHref,
   merge,
-  isActiveEntry
+  isActiveEntryId
 };

--- a/client/js/utils/index.spec.js
+++ b/client/js/utils/index.spec.js
@@ -8,7 +8,7 @@ import {
   clearLocalStorage,
   getViewFromHref,
   merge,
-  isActiveEntry
+  isActiveEntryId
 } from './index';
 
 describe('utils', () => {
@@ -176,7 +176,7 @@ describe('utils', () => {
     });
   });
 
-  describe('isActiveEntry', () => {
+  describe('isActiveEntryId', () => {
     let el;
 
     beforeEach(() => {
@@ -186,17 +186,17 @@ describe('utils', () => {
     });
 
     it('should return false when entry is undefined', () => {
-      expect(isActiveEntry(el, 0)).to.be.false;
+      expect(isActiveEntryId(el, 0)).to.be.false;
     });
 
     it('should return false when the given ids don\'t match', () => {
       el.state.entry = { id: 1 };
-      expect(isActiveEntry(el, 0)).to.be.false;
+      expect(isActiveEntryId(el, 0)).to.be.false;
     });
 
     it('should return true when the given ids match', () => {
       el.state.entry = { id: 0 };
-      expect(isActiveEntry(el, 0)).to.be.true;
+      expect(isActiveEntryId(el, 0)).to.be.true;
     });
 
   });

--- a/client/js/utils/index.spec.js
+++ b/client/js/utils/index.spec.js
@@ -7,7 +7,8 @@ import {
   applyFilters,
   clearLocalStorage,
   getViewFromHref,
-  merge
+  merge,
+  isActiveEntry
 } from './index';
 
 describe('utils', () => {
@@ -173,6 +174,31 @@ describe('utils', () => {
       expect(keys.includes('a'));
       expect(keys.includes('b'));
     });
+  });
+
+  describe('isActiveEntry', () => {
+    let el;
+
+    beforeEach(() => {
+      el = {
+        state: {}
+      };
+    });
+
+    it('should return false when entry is undefined', () => {
+      expect(isActiveEntry(el, 0)).to.be.false;
+    });
+
+    it('should return false when the given ids don\'t match', () => {
+      el.state.entry = { id: 1 };
+      expect(isActiveEntry(el, 0)).to.be.false;
+    });
+
+    it('should return true when the given ids match', () => {
+      el.state.entry = { id: 0 };
+      expect(isActiveEntry(el, 0)).to.be.true;
+    });
+
   });
   
 });

--- a/server/bl/entry-bl.js
+++ b/server/bl/entry-bl.js
@@ -29,9 +29,7 @@ module.exports = function(Entry){
       var entryId = parseInt(params.id, 10);
       Entry.getEntryById(entryId).then(function (entry){
         if(!entry) return reject({status: 404, message: 'Entry not found.'});
-        if(!entry.isPublic && (!user || (user.id !== entry.ownerId))){
-          return reject({status: 404, message: 'Entry not found.'});
-        }
+        if(user.id !== entry.ownerId) return reject({status: 404, message: 'Entry not found.'});
         entry.isOwner = (user && user.id == entry.ownerId);
         delete entry.ownerId;
         return resolve(entry);

--- a/server/routes.js
+++ b/server/routes.js
@@ -7,17 +7,17 @@ var Sequelize = require('sequelize'),
 module.exports = function(app){
   /* REST endpoints */
   app.post('/api/user/login', user.attemptLogin);
-  app.post('/api/user/logout', function(req, res) {
+  app.post('/api/user/logout', app.restrict, function(req, res) {
     res.clearCookie('auth_token');
     res.clearCookie('logged_in');
     res.sendStatus(204);
   });
   app.post('/api/user', user.createAccount);
-  // app.put('/user/:id');
+  // app.patch('/user/:id');
   // app.delete('/user/:id')
   app.get('/api/entries/sync/:timestamp', app.restrict, entry.getUpdatesSinceTimestamp);
   app.get('/api/entries', app.restrict, entry.getAllEntriesByOwnerId);
-  app.get('/api/entry/:id', entry.getEntryById);
+  app.get('/api/entry/:id', app.restrict, entry.getEntryById);
   app.post('/api/entry', app.restrict, entry.createEntry);
   app.patch('/api/entry/:id', app.restrict, entry.updateEntry);
   app.delete('/api/entry/:id', app.restrict, entry.deleteEntry);

--- a/server/services/entry-service.js
+++ b/server/services/entry-service.js
@@ -90,6 +90,8 @@ module.exports = function(Entry, sequelize){
   }
 
   self.getEntryCount = function(){
-    return Entry.count();
+    return Entry.count({
+      where: { deleted: 0 }
+    });
   }
 }


### PR DESCRIPTION
* Add tests for `createEntry`
* Improve tests for `updateEntry` and `deleteEntry`
* And a race condition check to the `createEntry` and `updateEntry` functions
* Add a lot off comments
* Restrict the `GET(/api/entry/:id)` endpoint
* Remove `isPublic` check from the `GET(/api/entry/:id)` endpoint
* Make the `getEntryCount` function return the count of non-deleted entries
* Only ping the dyno while in production and switch to the `https` module so the dyno won't die every 15 minutes
