### PR TITLE
Updated favorites

### DIFF
--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -5,29 +5,32 @@ import Header from '../header';
 import Login from '../login';
 import Entries from '../entries';
 import Entry from '../entry';
+import DialogWrapper from '../dialog-wrapper';
 import Toast from '../toast';
 import { fire } from '../unifire';
 
 export default (props) => {
-  const dark = props.dark ? 'dark' : '';
   const toast = props.toastConfig ? 'toast' : '';
 
   return (
-    <div class={`app ${dark} ${toast}`}>
+    <div class={`app ${toast}`}>
+      <DialogWrapper
+        dark={props.dark}
+        entry={props.entry}
+        dialogMode={props.dialogMode}/>
       <Header
         view={props.view}
-        prevView={props.prevView}
         loggedIn={props.loggedIn}
         viewEntries={props.viewEntries}
         entry={props.entry}
         filter={props.filter}
         filterText={props.filterText}
-        showFilterInput={props.showFilterInput}
-        dark={props.dark}/>
+        showFilterInput={props.showFilterInput}/>
       <main>
         <Router onChange={fire('handleRouteChange')}>
           <Login path="/"/>
           <Entries path="/entries"
+            showFilterInput={props.showFilterInput}
             scrollPosition={props.scrollPosition}
             viewEntries={props.viewEntries}/>
           <Entry path="/entry/:id"

--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -19,6 +19,7 @@ export default (props) => {
         loggedIn={props.loggedIn}
         viewEntries={props.viewEntries}
         entry={props.entry}
+        filter={props.filter}
         filterText={props.filterText}
         showFilterInput={props.showFilterInput}
         dark={props.dark}/>

--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -10,7 +10,7 @@ import Toast from '../toast';
 import { fire } from '../unifire';
 
 export default (props) => {
-  const toast = props.toastConfig ? 'toast' : '';
+  const toast = props.toast ? 'toast' : '';
 
   return (
     <div class={`app ${toast}`}>
@@ -39,7 +39,7 @@ export default (props) => {
             viewEntries={props.viewEntries}
             entryIndex={props.entryIndex}/>
         </Router>
-        <Toast config={props.toastConfig}/>
+        <Toast toast={props.toast}/>
       </main>
     </div>
   );

--- a/client/components/app/index.js
+++ b/client/components/app/index.js
@@ -16,6 +16,7 @@ export default (props) => {
     <div class={`app ${dark} ${toast}`}>
       <Header
         view={props.view}
+        prevView={props.prevView}
         loggedIn={props.loggedIn}
         viewEntries={props.viewEntries}
         entry={props.entry}

--- a/client/components/dialog-wrapper/index.js
+++ b/client/components/dialog-wrapper/index.js
@@ -1,0 +1,66 @@
+import { h } from 'preact';
+import Dialog from '../dialog';
+import { fire } from '../unifire';
+
+const onLogout = e => {
+  e.stopPropagation();
+  fire('linkstate', { key: 'dialogMode', cb: function(){
+    fire('linkstate', { key: 'dialogMode', val: 'modal:logout' })();
+  }})();
+};
+
+const menu = (dark) => (
+  <ul>
+    <li onclick={fire('linkstate', {key: 'dark', val: !dark})}>{dark ? 'Light' : 'Dark'}</li>
+    <li onclick={onLogout}>Logout</li>
+  </ul>
+);
+
+const modal = (message, confirmText, onConfirm) => (
+  <div>
+    <div class="modal-message">{message}</div>
+    <div>
+      <button class="mdl-button">Cancel</button>
+      <button class="mdl-button" onclick={onConfirm}>{confirmText}</button>
+    </div>
+  </div>
+);
+
+const modalOptions = (modalType, entry) => {
+  if(modalType === 'delete'){
+    return {
+      message: 'Delete this entry?',
+      confirmText: 'Delete',
+      onConfirm: fire('deleteEntry', { id: entry.id })
+    }
+  }
+  if(modalType === 'logout'){
+    return {
+      message: 'Logout?',
+      confirmText: 'Logout',
+      onConfirm: fire('logout')
+    }
+  }
+};
+
+export default ({ dialogMode, dark, entry }) => {
+  if(!dialogMode) return;
+
+  let markup;
+  if(dialogMode === 'menu'){
+    markup = menu(dark);
+  } else {
+    const modalType = dialogMode.split(':')[1];
+    if(modalType === 'delete' && !entry) return;
+    const { message, confirmText, onConfirm } = modalOptions(modalType, entry);
+    markup = modal(message, confirmText, onConfirm);
+  }
+
+  dialogMode = dialogMode.split(':')[0];
+
+  return (
+    <Dialog dialogMode={dialogMode}>
+      { markup }
+    </Dialog>
+  );
+};

--- a/client/components/dialog/index.js
+++ b/client/components/dialog/index.js
@@ -1,0 +1,10 @@
+import { h } from 'preact';
+import { fire } from '../unifire';
+
+export default ({ dialogMode, children }) => (
+  <div class={`modal-overlay modal-${dialogMode} fade-in`} onclick={fire('linkstate', {key: 'dialogMode'})}>
+    <div class={`modal-dialog modal-${dialogMode} grow`}>
+      { children[0] }
+    </div>
+  </div>
+);

--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -15,30 +15,19 @@ export default class Entries extends Component {
     document.body.onscroll = null;
   }
 
-  /**
-   * Only render if viewEntries has changed
-   * or if scroll position has not changed.
-   * The scroll position condition is
-   * necessary becasue Router wraps pushState
-   * so that it scrolls each pushState to the
-   * top of the screen. However, I don't want
-   * that to happen when navigating to /entries.
-   */
   shouldComponentUpdate(np) {
-    const op = this.props;
-    return op.viewEntries !== np.viewEntries
-      || op.scrollPosition === np.scrollPosition;
+    return this.props.viewEntries !== np.viewEntries;
   }
 
   render({ showFilterInput, viewEntries, scrollPosition }) {
     viewEntries = viewEntries || [];
     if(showFilterInput && !viewEntries.length) return;
-    document.body.scrollTop = scrollPosition;
     if(!viewEntries.length){
       return (
         <h2 class="center-text fade-up">It's empty in here!</h2>
       );
     }
+    document.body.scrollTop = scrollPosition;
     return (
       <ScrollViewport class="entry-list fade-down" rowHeight={83} overscan={20}>
         {viewEntries.map(entry => <EntryPreview entry={entry}/>)}

--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -10,7 +10,7 @@ export default class Entries extends Component {
       fire('linkstate', { key: 'scrollPosition', val: document.body.scrollTop })();
     }, 50);
   }
-  
+
   componentWillUnmount() {
     document.body.onscroll = null;
   }
@@ -30,9 +30,10 @@ export default class Entries extends Component {
       || op.scrollPosition === np.scrollPosition;
   }
 
-  render({ viewEntries, scrollPosition }) {
-    document.body.scrollTop = scrollPosition;
+  render({ showFilterInput, viewEntries, scrollPosition }) {
     viewEntries = viewEntries || [];
+    if(showFilterInput && !viewEntries.length) return;
+    document.body.scrollTop = scrollPosition;
     if(!viewEntries.length){
       return (
         <h2 class="center-text fade-up">It's empty in here!</h2>

--- a/client/components/entry-preview/index.js
+++ b/client/components/entry-preview/index.js
@@ -13,6 +13,7 @@ export default class EntryPreview extends Component {
   }
 
   render({ entry }) {
+    const favoriteIcon = entry && entry.favorited ? 'star-filled' : 'star-empty';
     const fadeRight = entry.slideIn ? 'fade-right' : '';
     if(fadeRight) setTimeout(fire('removeSlideInProp'), 450);
 
@@ -35,8 +36,9 @@ export default class EntryPreview extends Component {
         </a>
 
         <span class="nav-set right dark-fill entry-preview--icons">
-          <Icon icon="copy" key={entry.id + 'copy'} onclick={this.copy}/>
           <Icon icon="delete" key="delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})}/>
+          <Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })}/>
+          <Icon icon="copy" key={entry.id + 'copy'} onclick={this.copy}/>
         </span>
       </div>
     );

--- a/client/components/entry-preview/index.js
+++ b/client/components/entry-preview/index.js
@@ -36,9 +36,9 @@ export default class EntryPreview extends Component {
         </a>
 
         <span class="nav-set right dark-fill entry-preview--icons">
-          <Icon icon="delete" key="delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})}/>
-          <Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })}/>
           <Icon icon="copy" key={entry.id + 'copy'} onclick={this.copy}/>
+          <Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })}/>
+          <Icon icon="delete" key="delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})}/>
         </span>
       </div>
     );

--- a/client/components/entry-preview/index.js
+++ b/client/components/entry-preview/index.js
@@ -26,7 +26,7 @@ export default class EntryPreview extends Component {
                 class="entry-link">
                 {entry.date}
               </span>
-        
+
             </div>
 
             <div class="second-row">
@@ -38,7 +38,6 @@ export default class EntryPreview extends Component {
         <span class="nav-set right dark-fill entry-preview--icons">
           <Icon icon="copy" key={entry.id + 'copy'} onclick={this.copy}/>
           <Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })}/>
-          {/* <Icon icon="delete" key="delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})}/> */}
         </span>
       </div>
     );

--- a/client/components/entry-preview/index.js
+++ b/client/components/entry-preview/index.js
@@ -38,7 +38,7 @@ export default class EntryPreview extends Component {
         <span class="nav-set right dark-fill entry-preview--icons">
           <Icon icon="copy" key={entry.id + 'copy'} onclick={this.copy}/>
           <Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })}/>
-          <Icon icon="delete" key="delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})}/>
+          {/* <Icon icon="delete" key="delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})}/> */}
         </span>
       </div>
     );

--- a/client/components/entry/index.js
+++ b/client/components/entry/index.js
@@ -43,9 +43,9 @@ export default class Entry extends Component {
     }
 
     var obj = {
+      entry: {},
       property: property,
-      entryId: this.props.entry.id,
-      entry: {}
+      entryId: this.props.entry.id
     }
     obj.entry[property] = e.target.innerText.trim();
 

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -4,8 +4,6 @@ import { fire } from '../../components/unifire';
 import copyText from '../../js/copy-text';
 import debounce from '../../js/debounce';
 
-const supportedIcons = ['star-filled', 'star-empty', 'clear'];
-
 export default class Header extends Component {
 	showFilterText = () => {
 		fire('linkstate', {key: 'showFilterInput', val: true, cb: function(){
@@ -24,18 +22,12 @@ export default class Header extends Component {
 		copyText(date + ' ' + text);
 	}
 
-	render({ view, prevView, loggedIn, viewEntries, entry, filter, filterText, showFilterInput, dark }) {
+	render({ view, loggedIn, viewEntries, entry, filter, filterText, showFilterInput }) {
 		if(!loggedIn) return null;
 		const entryCount = Array.isArray(viewEntries) ? viewEntries.length : 0;
 		const filterIcon = filter === '' ? 'star-empty' : 'star-filled';
 		const filterTo = filter === '' ? 'favorites' : '';
 		const favoriteIcon = entry && entry.favorited ? 'star-filled' : 'star-empty';
-		// let favoriteDirection;
-		// if(entry && prevView !== '/entry'){
-		// 	favoriteDirection = entry.favorited ? 'up' : 'down';
-		// }
-		// const favoriteDirection = entry && prevView !== '/entry' && entry.favorited ? 'up' : 'down';
-		const formDirection = prevView === '/entry' && showFilterInput ? 'down' : 'up';
 
 		return (
 			<header class="elevated">
@@ -54,7 +46,7 @@ export default class Header extends Component {
 
 					<div class="nav-set flex-grow nav-search">
 						{view === '/entries' && showFilterInput &&
-							<form class={`search-form fade-${formDirection}`} onsubmit={this.cancelAndBlur}>
+							<form class="search-form fade-up" onsubmit={this.cancelAndBlur}>
 								<span class="nav-set">
 									<Icon icon={filterIcon} onclick={fire('linkstate', { key: 'filter', val: filterTo })}/>
 								</span>
@@ -62,14 +54,17 @@ export default class Header extends Component {
 						    	id="filterTextInput"
 						    	autocomplete="off"
 						    	value={filterText}
-						    	placeholder="Search entries"
+						    	placeholder="Search"
 						    	oninput={debounce(fire('filterByText'), 100)}/>
+								<span class="nav-set">
+									<span class="search-entry-count">{viewEntries.length}</span>
+								</span>
 						  </form>
 						}
 					</div>
 
 					<div class="nav-set">
-					  {view === '/entries' && !showFilterInput && !filter &&
+					  {view === '/entries' && !showFilterInput && !filter && !filterText &&
 					  	<Icon icon="search" key="header-search" onclick={this.showFilterText} class="fade-down"/>
 						}
 						{(view === '/entry' || view === '/new') &&
@@ -79,9 +74,9 @@ export default class Header extends Component {
 							<Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })} class="fade-up"/>
 						}
 						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&
-							<Icon icon="delete" key="header-delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})} class="fade-up"/>
+							<Icon icon="delete" key="header-delete" onclick={fire('linkstate', {key: 'dialogMode', val: 'modal:delete'})} class="fade-up"/>
 						}
-					  <Icon icon="menu" key="header-menu" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'menu', data: dark}})}/>
+					  <Icon icon="menu" key="header-menu" onclick={fire('linkstate', {key: 'dialogMode', val: 'menu'})}/>
 					</div>
 
 					{view === '/entries' &&

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -75,7 +75,7 @@ export default class Header extends Component {
 						{(view === '/entry' || view === '/new') &&
 							<Icon icon="copy" key="header-copy" onclick={this.copy} class="fade-up"/>
 						}
-						{view === '/entry' && entry && !entry.newEntry &&
+						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&
 							<Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })} class="fade-up"/>
 						}
 						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -8,10 +8,14 @@ const supportedIcons = ['star-filled', 'star-empty', 'clear'];
 
 export default class Header extends Component {
 	handleBlur = (e) => {
-		const target = e.relatedTarget;
+		const target = e.relatedTarget || e.explicitOriginalTarget;
+		let id;
 		let icon;
-		if(target) icon = target.getAttribute('icon');
-		if(~supportedIcons.indexOf(icon) && this.base.contains(target)) return;
+		if(target){
+			id = target.id;
+			icon = target.getAttribute('icon');
+		}
+		if(id === 'filterTextInput' || ~supportedIcons.indexOf(icon) && this.base.contains(target)) return;
 		fire('blurTextFilter')();
 	}
 
@@ -68,7 +72,10 @@ export default class Header extends Component {
 						{view === '/entries' && showFilterInput &&
 							<form class="search-form grow" onsubmit={this.cancelAndBlur}>
 								<span class="nav-set">
-									<Icon icon={filterIcon} onclick={fire('linkstate', { key: 'filter', val: filterTo })}/>
+									<Icon
+										icon={filterIcon}
+										onblur={this.handleBlur}
+										onclick={fire('linkstate', { key: 'filter', val: filterTo })}/>
 								</span>
 						    <input
 						    	id="filterTextInput"
@@ -88,14 +95,14 @@ export default class Header extends Component {
 					  {view === '/entries' && !showFilterInput && !filter &&
 					  	<Icon icon="search" key="header-search" onclick={this.showFilterText} class="fade-down"/>
 						}
+						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&
+							<Icon icon="delete" key="header-delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})} class="fade-up"/>
+						}
 						{view === '/entry' && entry && !entry.newEntry &&
 							<Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })} class="fade-up"/>
 						}
-					  {(view === '/entry' || view === '/new') &&
-					  	<Icon icon="copy" key="header-copy" onclick={this.copy} class="fade-up"/>
-						}
-						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&
-							<Icon icon="delete" key="header-delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})} class="fade-up"/>
+						{(view === '/entry' || view === '/new') &&
+							<Icon icon="copy" key="header-copy" onclick={this.copy} class="fade-up"/>
 						}
 					  <Icon icon="menu" key="header-menu" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'menu', data: dark}})}/>
 					</div>

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -72,14 +72,14 @@ export default class Header extends Component {
 					  {view === '/entries' && !showFilterInput && !filter &&
 					  	<Icon icon="search" key="header-search" onclick={this.showFilterText} class="fade-down"/>
 						}
-						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&
-							<Icon icon="delete" key="header-delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})} class="fade-up"/>
+						{(view === '/entry' || view === '/new') &&
+							<Icon icon="copy" key="header-copy" onclick={this.copy} class="fade-up"/>
 						}
 						{view === '/entry' && entry && !entry.newEntry &&
 							<Icon icon={favoriteIcon} onclick={fire('toggleFavorite', { id: entry.id, favorited: !entry.favorited })} class="fade-up"/>
 						}
-						{(view === '/entry' || view === '/new') &&
-							<Icon icon="copy" key="header-copy" onclick={this.copy} class="fade-up"/>
+						{entry && !entry.newEntry && (view === '/entry' || view === '/new') &&
+							<Icon icon="delete" key="header-delete" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'confirm delete', data: entry.id}})} class="fade-up"/>
 						}
 					  <Icon icon="menu" key="header-menu" onclick={fire('linkstate', {key: 'toastConfig', val: {type: 'menu', data: dark}})}/>
 					</div>

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -45,6 +45,7 @@ export default class Header extends Component {
 		if(!loggedIn) return null;
 		const vw = window.innerWidth;
 		const entryCount = Array.isArray(viewEntries) ? viewEntries.length : 0;
+		const entryCountDisplay = (vw < 425 && showFilterInput) ? entryCount : `${entryCount} Entries`;
 		const filterIcon = filter === '' ? 'star-empty' : 'star-filled';
 		const filterTo = filter === '' ? 'favorites' : '';
 		const favoriteIcon = entry && entry.favorited ? 'star-filled' : 'star-empty';
@@ -52,8 +53,8 @@ export default class Header extends Component {
 			<header class="elevated">
 				<div class="inner-header">
 					<div class="nav-set flex-grow">
-						{view === '/entries' && (vw > 400 || !showFilterInput) &&
-							<h3 class="fade-down">{entryCount} Entries</h3>
+						{view === '/entries' && (vw > 350 || !showFilterInput) &&
+							<h3 class="fade-down">{entryCountDisplay}</h3>
 						}
 
 						{(view === '/entry' || view === '/new') &&

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -35,7 +35,7 @@ export default class Header extends Component {
 		// 	favoriteDirection = entry.favorited ? 'up' : 'down';
 		// }
 		// const favoriteDirection = entry && prevView !== '/entry' && entry.favorited ? 'up' : 'down';
-		const formDirection = prevView === '/entry' && filter || filterText ? 'down' : 'up';
+		const formDirection = prevView === '/entry' && showFilterInput ? 'down' : 'up';
 
 		return (
 			<header class="elevated">

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -7,30 +7,9 @@ import debounce from '../../js/debounce';
 const supportedIcons = ['star-filled', 'star-empty', 'clear'];
 
 export default class Header extends Component {
-	handleBlur = (e) => {
-		const target = e.relatedTarget || e.explicitOriginalTarget;
-		let id;
-		let icon;
-		if(target){
-			id = target.id;
-			icon = target.getAttribute('icon');
-		}
-		if(id === 'filterTextInput' || ~supportedIcons.indexOf(icon) && this.base.contains(target)) return;
-		fire('blurTextFilter')();
-	}
-
-	clearFilters = (filter, filterText) => {
-		if(filter || filterText){
-			this.base.querySelector('#filterTextInput').focus();
-			fire('clearFilters')();
-		} else {
-			fire('linkstate', { key: 'showFilterInput', val: false })();
-		}
-	}
-
 	showFilterText = () => {
 		fire('linkstate', {key: 'showFilterInput', val: true, cb: function(){
-			this.base.querySelector('#filterTextInput').focus();
+			setTimeout(() => this.base.querySelector('#filterTextInput').focus(), 200);
 		}})();
 	}
 
@@ -45,53 +24,47 @@ export default class Header extends Component {
 		copyText(date + ' ' + text);
 	}
 
-	render({ view, loggedIn, viewEntries, entry, filter, filterText, showFilterInput, dark }) {
+	render({ view, prevView, loggedIn, viewEntries, entry, filter, filterText, showFilterInput, dark }) {
 		if(!loggedIn) return null;
-		const vw = window.innerWidth;
 		const entryCount = Array.isArray(viewEntries) ? viewEntries.length : 0;
-		const entryCountDisplay = (vw < 425 && showFilterInput) ? entryCount : `${entryCount} Entries`;
 		const filterIcon = filter === '' ? 'star-empty' : 'star-filled';
 		const filterTo = filter === '' ? 'favorites' : '';
 		const favoriteIcon = entry && entry.favorited ? 'star-filled' : 'star-empty';
+		// debugger
+		const formDirection = prevView === '/entry' && showFilterInput ? 'down' : 'up';
+
 		return (
 			<header class="elevated">
 				<div class="inner-header">
-					<div class="nav-set flex-grow">
-						{view === '/entries' && (vw > 350 || !showFilterInput) &&
-							<h3 class="fade-down">{entryCountDisplay}</h3>
+					<div class="nav-set">
+						{view === '/entries' && !showFilterInput &&
+							<h3 class="fade-down">{`${entryCount} Entries`}</h3>
 						}
 
-						{(view === '/entry' || view === '/new') &&
+						{(view === '/entry' || view === '/new' || (view === '/entries' && showFilterInput)) &&
 							<a href="/entries">
 								<Icon icon="back" key="header-back" class="fade-up"/>
 							</a>
 						}
 					</div>
 
-					<div class="nav-set nav-search">
+					<div class="nav-set flex-grow nav-search">
 						{view === '/entries' && showFilterInput &&
-							<form class="search-form grow" onsubmit={this.cancelAndBlur}>
+							<form class={`search-form fade-${formDirection}`} onsubmit={this.cancelAndBlur}>
 								<span class="nav-set">
-									<Icon
-										icon={filterIcon}
-										onblur={this.handleBlur}
-										onclick={fire('linkstate', { key: 'filter', val: filterTo })}/>
+									<Icon icon={filterIcon} onclick={fire('linkstate', { key: 'filter', val: filterTo })}/>
 								</span>
 						    <input
 						    	id="filterTextInput"
 						    	autocomplete="off"
 						    	value={filterText}
 						    	placeholder="Search entries"
-						    	oninput={debounce(fire('filterByText'), 100)}
-						    	onblur={this.handleBlur}/>
+						    	oninput={debounce(fire('filterByText'), 100)}/>
 						  </form>
 						}
 					</div>
 
 					<div class="nav-set">
-						{view === '/entries' && (showFilterInput || filter === 'favorites') &&
-							<Icon icon="clear" key="header-clear" onclick={() => this.clearFilters(filter, filterText)} class="fade-up"/>
-					  }
 					  {view === '/entries' && !showFilterInput && !filter &&
 					  	<Icon icon="search" key="header-search" onclick={this.showFilterText} class="fade-down"/>
 						}

--- a/client/components/header/index.js
+++ b/client/components/header/index.js
@@ -30,8 +30,12 @@ export default class Header extends Component {
 		const filterIcon = filter === '' ? 'star-empty' : 'star-filled';
 		const filterTo = filter === '' ? 'favorites' : '';
 		const favoriteIcon = entry && entry.favorited ? 'star-filled' : 'star-empty';
-		// debugger
-		const formDirection = prevView === '/entry' && showFilterInput ? 'down' : 'up';
+		// let favoriteDirection;
+		// if(entry && prevView !== '/entry'){
+		// 	favoriteDirection = entry.favorited ? 'up' : 'down';
+		// }
+		// const favoriteDirection = entry && prevView !== '/entry' && entry.favorited ? 'up' : 'down';
+		const formDirection = prevView === '/entry' && filter || filterText ? 'down' : 'up';
 
 		return (
 			<header class="elevated">

--- a/client/components/icon/index.js
+++ b/client/components/icon/index.js
@@ -37,11 +37,24 @@ function getSVG(icon) {
               <path d="M15.4 7.4L14 6l-6 6 6 6 1.4-1.4-4.6-4.6z"/>
               <path d="M0 0h24v24H0z" fill="none"/>
             </g>
+    case 'star-empty':
+      return <g>
+            <path d="M22 9.2l-7.2-.6L12 2 9.2 8.6 2 9.2 7.5 14l-1.7 7 6.2-3.7 6.2 3.7-1.6-7L22 9.2zm-10 6.2l-3.8 2.3 1-4.3L6 10.5l4.4-.4 1.7-4 1.7 4 4.4.4-3.3 2.9 1 4.3-3.8-2.3z"/>
+            <path d="M0 0h24v24H0z" fill="none"/>
+          </g>
+    case 'star-filled':
+      return <g>
+            <path d="M0 0h24v24H0z" fill="none"/>
+            <path d="M12 17.3l6.2 3.7-1.7-7L22 9.2l-7.2-.6L12 2 9.2 8.6 2 9.2 7.5 14l-1.7 7z"/>
+            <path d="M0 0h24v24H0z" fill="none"/>
+          </g>
   }
 }
 
 export default (props) => (
-  <svg xmlns="http://www.w3.org/2000/svg" {...props}>
-    { getSVG(props.icon) }
-  </svg>
+  <button data-is="svg" {...props}>
+    <svg xmlns="http://www.w3.org/2000/svg">
+      { getSVG(props.icon) }
+    </svg>
+  </button>
 );

--- a/client/components/icon/index.js
+++ b/client/components/icon/index.js
@@ -52,9 +52,7 @@ function getSVG(icon) {
 }
 
 export default (props) => (
-  <button data-is="svg" {...props}>
-    <svg xmlns="http://www.w3.org/2000/svg">
-      { getSVG(props.icon) }
-    </svg>
-  </button>
+  <svg xmlns="http://www.w3.org/2000/svg" {...props}>
+    { getSVG(props.icon) }
+  </svg>
 );

--- a/client/components/toast/index.js
+++ b/client/components/toast/index.js
@@ -15,34 +15,11 @@ export default class Toast extends Component {
     }
   }
 
-  handleDeleteEntry = () => {
-    fire('deleteEntry', {id: this.props.config.data})();
-    fire('linkstate', {key: 'toastConfig'})();
-  }
-
-  handleToggleDarkMode = () => {
-    fire('linkstate', {key: 'dark', val: !this.props.config.data})();
-    fire('linkstate', {key: 'toastConfig'})();
-  }
-
   render({config}) {
     return (
       <toast class={!!config ? 'show' : ''}>
         {config && config.type === 'text copied' &&
           <span class="toast-label">Entry copied to clipboard!</span>
-        }
-        {config && config.type === 'confirm delete' &&
-          <div>
-            <button class="mdl-button left" onclick={this.handleDeleteEntry}>Delete</button>
-            <button class="mdl-button right" onclick={fire('linkstate', {key: 'toastConfig'})}>Cancel</button>
-          </div>
-        }
-        {config && config.type === 'menu' &&
-          <div>
-            <button class="mdl-button left" onclick={fire('logout')}>Logout</button>
-            <button class="mdl-button" onclick={this.handleToggleDarkMode}>{config.data ? 'Light' : 'Dark'}</button>
-            <button class="mdl-button right" onclick={fire('linkstate', {key: 'toastConfig'})}>Cancel</button>
-          </div>
         }
       </toast>
     );

--- a/client/components/toast/index.js
+++ b/client/components/toast/index.js
@@ -1,27 +1,7 @@
-import { h, Component } from 'preact';
-import { fire } from '../unifire';
+import { h } from 'preact';
 
-let timeout;
-
-export default class Toast extends Component {
-  componentDidUpdate() {
-    if(timeout) clearTimeout(timeout);
-    let config = this.props.config;
-    if(!config) return;
-    if(config.type === 'text copied'){
-      timeout = setTimeout(function(){
-        fire('linkstate', {key: 'toastConfig'})();
-      }, 2000);
-    }
-  }
-
-  render({config}) {
-    return (
-      <toast class={!!config ? 'show' : ''}>
-        {config && config.type === 'text copied' &&
-          <span class="toast-label">Entry copied to clipboard!</span>
-        }
-      </toast>
-    );
-  }
-}
+export default ({ toast }) => (
+  <toast class={!toast ? '' : 'show'}>
+    <span class="toast-label">{toast}</span>
+  </toast>
+);

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -269,6 +269,7 @@ header .nav-set > *:not(h1):not(form) {
 
 .search-form input {
   padding: 8px;
+  margin: 0;
   width: 90%;
   background: transparent;
   border: none;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -97,9 +97,9 @@ svg {
   float: right;
 }
 
-.left {
+/* .left {
   float: left;
-}
+} */
 
 .center-text {
   text-align: center;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -23,10 +23,6 @@ body {
   font-size: 16px;
 }
 
-/* body.dialog {
-  overflow: hidden;
-} */
-
 main {
   margin: 0 auto;
   max-width: 800px;
@@ -96,10 +92,6 @@ svg {
 .right {
   float: right;
 }
-
-/* .left {
-  float: left;
-} */
 
 .center-text {
   text-align: center;
@@ -366,10 +358,6 @@ header .nav-set > *:not(h1):not(form) {
   background-color: #00000080;
 }
 
-/* .modal-overlay.modal-menu {
-
-} */
-
 .modal-dialog {
   font-size: 18px;
   display: inline-block;
@@ -412,8 +400,8 @@ header .nav-set > *:not(h1):not(form) {
 .modal-dialog.modal-menu {
   position: fixed;
   width: 150px;
-  top: 10px;
-  right: 10px;
+  top: 5px;
+  right: 5px;
 }
 
 @media (min-width: 1019px) {
@@ -467,10 +455,6 @@ body.dark .search-form {
 body.dark .modal-dialog {
   background-color: var(--theme-dark);
 }
-
-/* body.dark .modal-dialog button {
-  color: var(--theme-white);
-} */
 
 body.dark .dark-fill svg {
   fill: #c5c5c5;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -46,6 +46,16 @@ svg {
   width: 24px;
 }
 
+button[data-is="svg"] {
+  background: none;
+	color: inherit;
+  border: none;
+  padding: 0;
+	font: inherit;
+  cursor: pointer;
+  outline: inherit;
+}
+
 .hidden {
   visibility: hidden;
 }
@@ -207,9 +217,8 @@ svg {
   right: -12.5px;
 }
 
-.entry-preview--icons svg {
-  padding-top: 10px;
-  padding-bottom: 5px;
+.entry-preview--icons button[data-is="svg"] {
+  padding: 10px 12.5px 5px;
 }
 
 .entry-preview .entry-link {
@@ -243,7 +252,7 @@ header .nav-set h3 {
   padding: 14px 15px;
 }
 
-header .nav-set > *:not(h1) {
+header .nav-set > *:not(h1):not(form) {
   padding: 12.5px;
 }
 
@@ -251,14 +260,21 @@ header .nav-set > *:not(h1) {
   flex: 1 2;
 }
 
+.nav-search {
+  flex-shrink: 1000;
+}
+
 .search-form {
   margin: 0;
+  padding: 0;
   max-width: 300px;
+  display: flex;
+  justify-content: flex-start;
 }
 
 .search-form input {
   padding: 8px;
-  width: 100%;
+  width: 75%;
   background: transparent;
   border: none;
   outline: 0;

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -46,16 +46,6 @@ svg {
   width: 24px;
 }
 
-button[data-is="svg"] {
-  background: none;
-	color: inherit;
-  border: none;
-  padding: 0;
-	font: inherit;
-  cursor: pointer;
-  outline: inherit;
-}
-
 .hidden {
   visibility: hidden;
 }
@@ -217,7 +207,7 @@ button[data-is="svg"] {
   right: -12.5px;
 }
 
-.entry-preview--icons button[data-is="svg"] {
+.entry-preview--icons svg {
   padding: 10px 12.5px 5px;
 }
 
@@ -265,16 +255,21 @@ header .nav-set > *:not(h1):not(form) {
 }
 
 .search-form {
-  margin: 0;
+  background-color: #676767;
+  margin: 5.5px;
   padding: 0;
-  max-width: 300px;
   display: flex;
   justify-content: flex-start;
+  border-radius: 10px;
+}
+
+.search-form .nav-set svg {
+  padding: 7.5px;
 }
 
 .search-form input {
   padding: 8px;
-  width: 150px;
+  width: 90%;
   background: transparent;
   border: none;
   outline: 0;
@@ -381,6 +376,10 @@ toast.show {
 
 .app.dark header {
   background-color: #424242;
+}
+
+.app.dark .search-form {
+  background-color: #000;
 }
 
 .app.dark .dark-fill svg {

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -2,6 +2,7 @@
 
 :root {
   --theme-blue: #4285F4;
+  --theme-dark: #424242;
   --theme-white: #fff;
   --theme-dark-text: #ccc;
 }
@@ -18,9 +19,13 @@
 body {
   margin: 0;
   font-family: 'Trebuchet MS', Helvetica, sans-serif;
-  color: #424242;
+  color: var(--theme-dark);
   font-size: 16px;
 }
+
+/* body.dialog {
+  overflow: hidden;
+} */
 
 main {
   margin: 0 auto;
@@ -36,7 +41,7 @@ input {
 }
 
 a, a:visited {
-  color: #424242;
+  color: var(--theme-dark);
   text-decoration: none;
 }
 
@@ -109,18 +114,15 @@ svg {
 }
 
 .mdl-button {
-  background: transparent;
+  background: 0 0;
   border: none;
-  color: var(--theme-white);
+  color: var(--theme-dark);
   position: relative;
-  height: 50px;
-  padding: 0 16px;
-  font-size: 14px;
-  font-weight: 500;
-  text-transform: uppercase;
-  outline: none;
+  padding: 16px;
+  font-size: 16px;
+  outline: 0;
   cursor: pointer;
-  line-height: 36px;
+  line-height: 10px;
 }
 
 /* Login */
@@ -256,21 +258,29 @@ header .nav-set > *:not(h1):not(form) {
 
 .search-form {
   background-color: #676767;
-  margin: 5.5px;
+  margin: 5.5px 0;
   padding: 0;
   display: flex;
   justify-content: flex-start;
   border-radius: 10px;
 }
 
-.search-form .nav-set svg {
+.search-form .nav-set > svg {
   padding: 7.5px;
 }
 
+.search-form .nav-set > .search-entry-count {
+  padding: 10px;
+  width: 35px;
+  text-align: right;
+  text-align: center;
+}
+
 .search-form input {
+  flex: 10;
   padding: 8px;
   margin: 0;
-  width: 90%;
+  width: 60%;
   background: transparent;
   border: none;
   outline: 0;
@@ -292,7 +302,7 @@ header .nav-set > *:not(h1):not(form) {
 
 @media (min-width: 1049px) {
   .button--fab.add-entry {
-    right: calc((100vw - 1000px) / 2)
+    right: calc((100vw - 1000px) / 2);
   }
 }
 
@@ -341,6 +351,77 @@ header .nav-set > *:not(h1):not(form) {
   }
 }
 
+/* Dialog */
+
+.modal-overlay {
+  position: fixed;
+  z-index: 2;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 100vw;
+}
+
+.modal-overlay.modal-modal {
+  background-color: #00000080;
+}
+
+/* .modal-overlay.modal-menu {
+
+} */
+
+.modal-dialog {
+  font-size: 18px;
+  display: inline-block;
+  position: relative;
+  background-color: #fff;
+  border-radius: 5px;
+  box-shadow: 0px 5px 20px 0px rgba(0,0,0,0.75);
+}
+
+.modal-dialog ul {
+  list-style: none;
+  padding: 5px;
+  margin: 0;
+  cursor: pointer;
+}
+
+.modal-dialog li {
+  padding: 12.5px 15px;
+}
+
+.modal-dialog p {
+  margin: 5px;
+}
+
+.modal-dialog.modal-modal {
+  width: 200px;
+  left: calc(50% - 100px);
+  top: calc(50% - 75px);
+  text-align: center;
+}
+
+.modal-dialog.modal-modal > div {
+  padding: 10px;
+}
+
+.modal-dialog.modal-modal .modal-message {
+  padding: 8px 10px;
+}
+
+.modal-dialog.modal-menu {
+  position: fixed;
+  width: 150px;
+  top: 10px;
+  right: 10px;
+}
+
+@media (min-width: 1019px) {
+  .modal-dialog.modal-menu {
+    right: calc((100vw - 1000px) / 2);
+  }
+}
+
 /* Toast */
 
 toast {
@@ -349,7 +430,7 @@ toast {
   position: fixed;
   text-align: center;
   height: 50px;
-  background-color: #424242;
+  background-color: var(--theme-dark);
   bottom: -50px;
   transition: bottom linear .1s;
   z-index: 2;
@@ -370,48 +451,69 @@ toast.show {
 
 /* Dark theme */
 
-.app.dark {
+body.dark {
   background-color: #000;
   color: var(--theme-white);
 }
 
-.app.dark header {
-  background-color: #424242;
+body.dark header {
+  background-color: var(--theme-dark);
 }
 
-.app.dark .search-form {
+body.dark .search-form {
   background-color: #000;
 }
 
-.app.dark .dark-fill svg {
+body.dark .modal-dialog {
+  background-color: var(--theme-dark);
+}
+
+/* body.dark .modal-dialog button {
+  color: var(--theme-white);
+} */
+
+body.dark .dark-fill svg {
   fill: #c5c5c5;
 }
 
-.app.dark .entry-preview .entry-link {
+body.dark .mdl-button {
+  color: var(--theme-white);
+}
+
+body.dark .entry-preview .entry-link {
   color: #f3f3f3;
 }
 
-.app.dark .entry-date {
+body.dark .entry-date {
   color: #e0e0e0;
 }
 
-.app.dark .entry-text {
+body.dark .entry-text {
   color: var(--theme-dark-text);
 }
 
-.app.dark .list-item .second-row {
+body.dark .list-item .second-row {
   color: var(--theme-dark-text);
 }
 
-.app.dark .button--fab.add-entry {
+body.dark .button--fab.add-entry {
   background-color: #2d50afe0;
 }
 
-.app.dark .elevated {
+body.dark .elevated {
   box-shadow: none;
 }
 
 /* Transitions */
+
+@keyframes fade-in {
+  from {
+    opacity: .25;
+  }
+  to {
+    opacity: 1;
+  }
+}
 
 @keyframes fade-up {
   from {
@@ -453,6 +555,10 @@ toast.show {
   to {
     transform: scale(1);
   }
+}
+
+.fade-in {
+  animation: fade-in ease .2s forwards;
 }
 
 .fade-up {

--- a/client/css/styles.css
+++ b/client/css/styles.css
@@ -274,7 +274,7 @@ header .nav-set > *:not(h1):not(form) {
 
 .search-form input {
   padding: 8px;
-  width: 75%;
+  width: 150px;
   background: transparent;
   border: none;
   outline: 0;

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -13,13 +13,13 @@ function boot (el, { entries }){
      * If the user is trying to view a specific entry,
      * I need to rerun the route handler once the
      * entries have been loaded from indexedDB.
-     * 
+     *
      * There may be a better way to manage this.
      * Perhaps I can make entry a computed property
      * that depends on view and entries. But that
      * would be wasteful since I only need to check
      * this on boot.
-     * 
+     *
      * I'll think about it, but for now I'm going to
      * leave this here.
      */
@@ -152,18 +152,18 @@ function createEntry (el, { entry, clientSync }){
    * In the event that the original POST failed for
    * whatever reason, results in the behavior you
    * would expect.
-   * 
+   *
    * My original thought was to allow the client
    * to generate the ID that ends up getting used in
    * the database as the entry's id. I settled on
    * this plan to avoid entry id collisions.
-   * 
+   *
    * I would like to revisit this at some point. It
    * makes sense that if an entry has the newEntry,
    * needsSync, and postPending flags all set to true,
    * then the front end would call an endpoint to
    * upsert than POST.
-   * 
+   *
    * For now, however, this is why clientSync
    * overrides postPending.
    */
@@ -189,7 +189,7 @@ function createEntrySuccess (el, oldId, response){
   /**
    * Because needsSync is a boolean, removing it here
    * can introduce a problem.
-   * 
+   *
    * For example, if I type one character and pause,
    * thereby triggering a POST, that will add the
    * needsSync and postPending flags to the entry. As
@@ -198,7 +198,7 @@ function createEntrySuccess (el, oldId, response){
    * needsSync flag to the entry) will be ignored when
    * the POST returns and triggers a removal of the
    * entry's needsSync flag.
-   * 
+   *
    * A potential solution could be to make needsSync
    * an integer so I can increment it when it needs
    * both a POST and a PATCH.
@@ -296,7 +296,7 @@ function deleteEntry (el, { id }){
 
   var entryIndex = findObjectIndexById(id, el.state.entries);
   if(entryIndex === -1) return;
-  
+
   el.state.entries[entryIndex].needsSync = true;
   el.state.entries[entryIndex].deleted = true;
   el.state.entries[entryIndex].text = '';

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -227,6 +227,14 @@ function createEntryFailure (el, oldId, err){
   console.log('createEntryFailure', err);
 };
 
+function toggleFavorite (el, { id, favorited }){
+  updateEntry(el, {
+    entry: { favorited },
+    property: 'favorited',
+    entryId: id
+  });
+};
+
 function updateEntry (el, { entry, property, entryId }){
   if(!entry || !property || typeof entryId !== 'number') return;
   var entryIndex = findObjectIndexById(entryId, el.state.entries);
@@ -375,6 +383,13 @@ function shiftEntry (el, count){
   if(entry) route('/entry/' + entry.id);
 };
 
+function clearFilters (el) {
+  el.set({
+    filter: '',
+    filterText: ''
+  });
+};
+
 function removeSlideInProp (el) {
   const entries = el.state.entries.map(entry => {
     delete entry.slideIn;
@@ -395,5 +410,7 @@ export default {
   filterByText,
   blurTextFilter,
   shiftEntry,
+  toggleFavorite,
+  clearFilters,
   removeSlideInProp: debounce(removeSlideInProp, 50)
 };

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -241,12 +241,6 @@ function updateEntry (el, { entry, property, entryId }){
   if(entryIndex === -1) return;
   var activeEntry = el.state.entries[entryIndex];
   var current = activeEntry[property];
-  /**
-   * Don't need this right now since the only values users can
-   * edit are strings. Will need this if I add favorites or
-   * other user-editable non-string values.
-   * if(typeof current === 'string') current = current.trim();
-   */
   var next = entry[property];
   if(current === next) return;
 

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -371,7 +371,7 @@ function filterByText (el, text, e){
 };
 
 function blurTextFilter (el){
-  if(!el.state.filterText){
+  if(!el.state.filter && !el.state.filterText){
     el.set({ showFilterInput: false });
   }
 };

--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -383,10 +383,11 @@ function shiftEntry (el, count){
   if(entry) route('/entry/' + entry.id);
 };
 
-function clearFilters (el) {
+function clearFilters (el, hideInput) {
   el.set({
     filter: '',
-    filterText: ''
+    filterText: '',
+    showFilterInput: hideInput === true ? false : el.state.showFilterInput
   });
 };
 

--- a/client/js/actions/global-actions.js
+++ b/client/js/actions/global-actions.js
@@ -2,10 +2,21 @@ import { fire } from '../../components/unifire';
 import { removeObjectByIndex, getViewFromPathname } from '../utils';
 import { route } from '../../components/router';
 
-function linkstate (el, { key, val, cb }){
+let timeout;
+
+function linkstate (el, { key, val, cb }) {
   let obj = {};
   obj[key] = val;
   el.set(obj, cb);
+};
+
+// Copied to clipboard confirmation is currently the only toast message.
+function setToast (el) {
+  if(timeout) clearTimeout(timeout);
+  el.set({ toast: 'Entry copied to clipboard!' });
+  timeout = setTimeout(() => {
+    el.set({ toast: '' });
+  }, 2000)
 };
 
 function handleRouteChange (el, e, url) {
@@ -14,14 +25,13 @@ function handleRouteChange (el, e, url) {
   if(view !== '/' && !el.state.loggedIn) return route('/', true);
   el.set({ view });
   handleRoute(el, view, url);
-  if(el.state.toastConfig) fire('linkstate', { key: 'toastConfig' })();
 };
 
 function handleRoute (el, view, url) {
   switch(view) {
     case '/':         handleLoginView(el);    break;
     case '/entries':  handleEntriesView(el);  break;
-    case '/entry':    // Fallthrough 
+    case '/entry':    // Fallthrough
     case '/new':      handleEntryView(url);   break;
     default:          route('/');             break;
   }
@@ -54,5 +64,6 @@ function handleEntryView (url) {
 
 export default {
   linkstate,
+  setToast,
   handleRouteChange
 };

--- a/client/js/actions/index.spec.js
+++ b/client/js/actions/index.spec.js
@@ -67,24 +67,26 @@ describe('actions', () => {
       //   expect(el.set.args[0][0].view).to.equal('/');
       // });
 
-      it('should reset toastConfig if it is set', (done) => {
-        const cb = sinon.spy();
-        const handler = (e) => {
-          if(e.detail[0] === 'linkstate'){
-            cb(e.detail[1]);
-          }
-        };
-        document.addEventListener(NAME, handler);
-        el.state.toastConfig = {};
-        Global.handleRouteChange(el, null, '/');
-        setTimeout(() => {
-          const detail = cb.args[0][0];
-          expect(detail.key).to.equal('toastConfig');
-          expect(detail.val).to.be.undefined;
-          document.removeEventListener(NAME, handler);
-          done();
-        });
-      });
+      /* This test may become useful in the future if I change how toast works, but it's not useful with my latest changes. */
+
+      // it('should reset toastConfig if it is set', (done) => {
+      //   const cb = sinon.spy();
+      //   const handler = (e) => {
+      //     if(e.detail[0] === 'linkstate'){
+      //       cb(e.detail[1]);
+      //     }
+      //   };
+      //   document.addEventListener(NAME, handler);
+      //   el.state.toastConfig = {};
+      //   Global.handleRouteChange(el, null, '/');
+      //   setTimeout(() => {
+      //     const detail = cb.args[0][0];
+      //     expect(detail.key).to.equal('toastConfig');
+      //     expect(detail.val).to.be.undefined;
+      //     document.removeEventListener(NAME, handler);
+      //     done();
+      //   });
+      // });
 
       it('should remove first entry from entries when appropriate when going to /entries', () => {
         el.state.loggedIn = true;

--- a/client/js/actions/index.spec.js
+++ b/client/js/actions/index.spec.js
@@ -2,7 +2,7 @@ import fetchMock from 'fetch-mock';
 import Global from './global-actions';
 import User from './user-actions';
 import Entry from './entry-actions';
-  
+
 describe('actions', () => {
   const NAME = 'UNIFIRE';
   let el;
@@ -45,7 +45,7 @@ describe('actions', () => {
       it('should set view when appropriate', () => {
         Global.handleRouteChange(el, null, '/entries');
         expect(el.set.called).to.be.false;
-    
+
         Global.handleRouteChange(el, null, '/');
         expect(el.set.args[0][0].view).to.equal('/');
       });
@@ -213,7 +213,7 @@ describe('actions', () => {
         setTimeout(() => {
           expect(localStorage.getItem('bogus')).to.be.null;
           expect(el.set.calledOnce).to.be.true;
-          expect(el.set.args[0][0].showFilterInput).to.be.undefined;
+          expect(el.set.args[0][0].showFilterInput).to.be.false;
           done();
         });
       });
@@ -246,11 +246,11 @@ describe('actions', () => {
       });
 
       // it('should call get entries in a callback', () => {
-        
+
       // });
 
       // it('should run handleRouteChange when state.view === "/entry"', () => {
-        
+
       // });
 
     });
@@ -295,7 +295,7 @@ describe('actions', () => {
             timestamp: 1234
           }
         });
-        
+
         el.state.entries = [];
         el.state.loggedIn = true;
         Entry.getEntries(el);
@@ -309,7 +309,7 @@ describe('actions', () => {
 
       it('should handle an error when fetching entries and timestamp when timestamp is undefined', (done) => {
         fetchMock.get('/api/entries', 500);
-        
+
         delete el.state.entries;
         el.state.loggedIn = true;
         Entry.getEntries(el);
@@ -327,7 +327,7 @@ describe('actions', () => {
             timestamp: 4321
           }
         });
-        
+
         el.state.loggedIn = true;
         el.state.timestamp = 1234;
         el.state.entries = [ { id: 0 }, { id: 1 } ];
@@ -351,7 +351,7 @@ describe('actions', () => {
             timestamp: 4321
           }
         });
-        
+
         el.state.loggedIn = true;
         el.state.timestamp = 1234;
         localStorage.setItem('timestamp', 1234);
@@ -365,7 +365,7 @@ describe('actions', () => {
 
       it('should handle an error when syncing entries', (done) => {
         fetchMock.get('/api/entries/sync/1234', 500);
-        
+
         el.state.loggedIn = true;
         el.state.timestamp = 1234;
         Entry.getEntries(el);
@@ -389,7 +389,7 @@ describe('actions', () => {
         });
         fetchMock.patch('/api/entry/1', 204);
         fetchMock.delete('/api/entry/2', 204);
-        
+
         el.state.loggedIn = true;
         el.state.timestamp = 1234;
         el.state.entries = [
@@ -418,7 +418,7 @@ describe('actions', () => {
           }
         });
         fetchMock.patch('/api/entry/0', 500);
-        
+
         el.state.loggedIn = true;
         el.state.timestamp = 1234;
         el.state.entries = [ { id: 0, date: '2017-01-01', text: 'what', needsSync: true } ];
@@ -617,7 +617,7 @@ describe('actions', () => {
         expect(firstCallArgs[0].entry.needsSync).to.be.true;
         expect(firstCallArgs[0].entries[0].date).to.equal(updateObj.entry.date);
         expect(firstCallArgs[0].entries[0].needsSync).to.be.true;
-        
+
         setTimeout(() => {
           const secondCallArgs = el.set.args[1];
           expect(secondCallArgs[0].entry.date).to.equal(updateObj.entry.date);
@@ -642,7 +642,7 @@ describe('actions', () => {
         expect(firstCallArgs[0].entry.needsSync).to.be.true;
         expect(firstCallArgs[0].entries[0].text).to.equal(updateObj.entry.text);
         expect(firstCallArgs[0].entries[0].needsSync).to.be.true;
-        
+
         setTimeout(() => {
           const secondCallArgs = el.set.args[1];
           expect(secondCallArgs[0].entry.text).to.equal(updateObj.entry.text);
@@ -667,7 +667,7 @@ describe('actions', () => {
         expect(firstCallArgs[0].entry.needsSync).to.be.true;
         expect(firstCallArgs[0].entries[0].text).to.equal(updateObj.entry.text);
         expect(firstCallArgs[0].entries[0].needsSync).to.be.true;
-        
+
         setTimeout(() => {
           expect(el.set.calledTwice).to.be.false;
           expect(console.log.calledWith('updateEntryFailure')).to.be.true;
@@ -705,7 +705,7 @@ describe('actions', () => {
         expect(firstCallArgs[0].entries[0].deleted).to.be.true;
         expect(firstCallArgs[0].entries[0].text).to.equal('');
         expect(typeof firstCallArgs[1]).to.equal('function');
-        
+
         setTimeout(() => {
           const secondCallArgs = el.set.args[1];
           expect(secondCallArgs[0].entries.length).to.equal(0);
@@ -723,7 +723,7 @@ describe('actions', () => {
         expect(firstCallArgs[0].entries[0].deleted).to.be.true;
         expect(firstCallArgs[0].entries[0].text).to.equal('');
         expect(typeof firstCallArgs[1]).to.equal('function');
-        
+
         setTimeout(() => {
           expect(el.set.calledTwice).to.be.false;
           expect(console.log.calledWith('deleteEntryFailure')).to.be.true;
@@ -831,7 +831,7 @@ describe('actions', () => {
     // describe('shiftEntry', () => {
 
     //   it('should route to the next or prior entry when appropriate', () => {
-        
+
     //   });
 
     // });

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -59,7 +59,7 @@ export default function getInitialState () {
     entry: undefined,
     // Included for documentation purporses
     // toastConfig: undefined,
-    // showFilterInput: false,
+    showFilterInput: false,
     view: getViewFromPathname(location.pathname),
     dark: localStorage.getItem('dark') === 'true',
     timestamp: localStorage.getItem('timestamp') || undefined

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -71,7 +71,7 @@ export default function getInitialState () {
     entryIndex: -1,
     entry: undefined,
     // Included for documentation purporses
-    // toastConfig: undefined,
+    // toast: '',
     // dialogMode: '',
     showFilterInput: false,
     view: getViewFromPathname(location.pathname),

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -8,22 +8,22 @@ const compute = (obj, prop, next, prev) => {
     // viewEntries
     case 'filter': // Fallthrough
     case 'entries': // Fallthrough
-    case 'filterText': {
-      obj.viewEntries = applyFilters(obj.filterText, obj.filter, obj.entries);
+    case 'filterText': // Fallthrough
+    case 'showFilterInput': {
+      obj.viewEntries = applyFilters(obj.filterText, obj.filter, obj.showFilterInput, obj.entries);
       return;
     }
 
-    // prevView
+    // entry
     // filter
     // filterText
+    // dialogMode
     // showFilterInput
     case 'view': {
-      obj.prevView = prev;
+      // obj.entry = undefined;
+      obj.dialogMode = '';
       if(prev === '/entries' && next === '/entries' || !obj.filter && !obj.filterText){
         return fire('clearFilters', true)();
-        // obj.filter = '';
-        // obj.filterText = '';
-        // obj.showFilterInput = false;
       }
     }
   }
@@ -37,7 +37,12 @@ const observe = (obj, prop, next, prev) => {
       return;
     }
     case 'timestamp':   localStorage.setItem('timestamp', next);   return;
-    case 'dark':        localStorage.setItem('dark', !!next);      return;
+    case 'dark':        {
+      localStorage.setItem('dark', !!next);
+      const func = next ? 'add' : 'remove';
+      document.body.classList[func]('dark');
+      return;
+    }
     case 'loggedIn':    if(next) setTimeout(fire('getEntries'));   return;
   }
 };
@@ -46,7 +51,6 @@ const handler = {
   set: function(obj, prop, next) {
     const prev = obj[prop];
     obj[prop] = next;
-    // obj.prevView = obj.view;
     compute(obj, prop, next, prev);
     observe(obj, prop, next, prev);
     return true;
@@ -68,9 +72,9 @@ export default function getInitialState () {
     entry: undefined,
     // Included for documentation purporses
     // toastConfig: undefined,
+    // dialogMode: '',
     showFilterInput: false,
     view: getViewFromPathname(location.pathname),
-    prevView: '',
     dark: localStorage.getItem('dark') === 'true',
     timestamp: localStorage.getItem('timestamp') || undefined
   };
@@ -78,6 +82,10 @@ export default function getInitialState () {
   get('entries').then((entries = []) => {
     fire('boot', { entries })();
   }).catch();
+
+  // Now that I'm setting a class to body, I
+  // have to ensure it gets set on load.
+  observe(null, 'dark', state.dark);
 
   return new Proxy(state, handler);
 };

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -13,12 +13,13 @@ const compute = (obj, prop, value) => {
     }
 
     // showFilterInput
-    case 'filter': // Fallthrough
-    case 'filterText': //Fallthrough
-    case 'showFilterInput': {
-      if(prop === 'showFilterInput' && !value)
-      obj.showFilterInput = (!!obj.filter || !!obj.filterText);
-    }
+    // case 'view': // Fallthrough
+    // case 'filter': // Fallthrough
+    // case 'filterText': //Fallthrough
+    // case 'showFilterInput': {
+    //   if(prop === 'showFilterInput' && value === true) return;
+    //   obj.showFilterInput = (!!obj.filter || !!obj.filterText);
+    // }
   }
 };
 

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -3,12 +3,21 @@ import cookie from '../cookie';
 import { sortObjectsByDate, getViewFromPathname, applyFilters, clearData } from '../utils';
 import { fire } from '../../components/unifire';
 
-const compute = (obj, prop) => {
+const compute = (obj, prop, value) => {
   switch(prop) {
+    // viewEntries
+    case 'filter': // Fallthrough
     case 'entries': // Fallthrough
     case 'filterText': {
-      obj.viewEntries = applyFilters(obj.filterText, obj.entries);
-      return;
+      obj.viewEntries = applyFilters(obj.filterText, obj.filter, obj.entries);
+    }
+
+    // showFilterInput
+    case 'filter': // Fallthrough
+    case 'filterText': //Fallthrough
+    case 'showFilterInput': {
+      if(prop === 'showFilterInput' && !value)
+      obj.showFilterInput = (!!obj.filter || !!obj.filterText);
     }
   }
 };
@@ -29,7 +38,7 @@ const observe = (obj, prop, value) => {
 const handler = {
   set: function(obj, prop, value) {
     obj[prop] = value;
-    compute(obj, prop);
+    compute(obj, prop, value);
     observe(obj, prop, value);
     return true;
   }
@@ -44,6 +53,7 @@ export default function getInitialState () {
     entries: [],
     viewEntries: [],
     scrollPosition: 0,
+    filter: '',
     filterText: '',
     entryIndex: -1,
     entry: undefined,

--- a/client/js/app-state/index.spec.js
+++ b/client/js/app-state/index.spec.js
@@ -1,6 +1,6 @@
 import { get, set } from 'idb-keyval';
 import getInitialState from './index';
-  
+
 describe('appState', () => {
   let state;
 
@@ -9,12 +9,13 @@ describe('appState', () => {
   };
 
   beforeEach(() => {
+    localStorage.clear();
     state = getInitialState();
   });
 
-  afterEach(() => {
-    localStorage.clear();
-  });
+  // afterEach(() => {
+  //   localStorage.clear();
+  // });
 
   it('should return correct defaults', () => {
     localStorage.setItem('bogus', 'hi');
@@ -54,15 +55,16 @@ describe('appState', () => {
     //   document.removeEventListener('boot', cb);
     //   done();
     // });
-    
+
     deleteCookie('logged_in');
   });
 
   it('should persist dark, timestamp, and entries (date-sorted) to localStorage when changed', (done) => {
+    // I have to manually clear localStorage here to avoid a race condition...
+    localStorage.clear();
     expect(localStorage.getItem('dark')).to.be.null;
     expect(localStorage.getItem('timestamp')).to.be.null;
     get('entries').then(entries => {
-      // This is a race condition since I call done below. Should I change it?
       expect(entries).to.be.undefined;
 
       state.dark = true;

--- a/client/js/app-state/index.spec.js
+++ b/client/js/app-state/index.spec.js
@@ -24,16 +24,18 @@ describe('appState', () => {
     expect(localStorage.getItem('bogus')).to.be.null;
     expect(typeof state).to.equal('object');
     expect(state.scrollPosition).to.equal(0);
-    // expect(state.view).to.equal('/');
-    // expect(state.showFilterInput).to.be.false;
+    expect(state.view).to.equal('/');
+    expect(state.showFilterInput).to.be.false;
     expect(state.filterText).to.equal('');
     expect(state.loggedIn).to.be.false;
     expect(state.timestamp).to.be.undefined;
     expect(state.entry).to.be.undefined;
+    expect(state.toast).to.be.undefined;
+    expect(state.dialogMode).to.be.undefined;
     expect(state.entryIndex).to.equal(-1);
     expect(state.entries.length).to.equal(0);
     expect(state.viewEntries.length).to.equal(0);
-    expect(state.toastConfig).to.be.undefined;
+    expect(state.toast).to.be.undefined;
     expect(state.dark).to.be.false;
 
     // const cb = sinon.spy();

--- a/client/js/copy-text/index.js
+++ b/client/js/copy-text/index.js
@@ -27,6 +27,6 @@ export default function copyText(text) {
   textarea.value = text;
   select(textarea);
   let successful = document.execCommand('copy');
-  if(successful) fire('linkstate', {key: 'toastConfig', val: {type: 'text copied'}})();
+  if(successful) fire('setToast')();
   hideKeyboard(textarea);
 }

--- a/client/js/copy-text/index.spec.js
+++ b/client/js/copy-text/index.spec.js
@@ -1,12 +1,12 @@
 import copyText from './index';
-  
+
 describe('copyText', () => {
 
-  it('should fire linkstate', (done) => {
+  it('should fire setToast', (done) => {
     const NAME = 'UNIFIRE';
     const cb = sinon.spy();
     const handler = (e) => {
-      if(e.detail[0] === 'linkstate'){
+      if(e.detail[0] === 'setToast'){
         cb(e.detail);
       }
     };
@@ -16,9 +16,7 @@ describe('copyText', () => {
     setTimeout(() => {
       expect(cb.called).to.be.true;
       const args = cb.args[0][0];
-      expect(args[0]).to.equal('linkstate');
-      expect(args[1].key).to.equal('toastConfig');
-      expect(args[1].val.type).to.equal('text copied');
+      expect(args[0]).to.equal('setToast');
       document.addEventListener(NAME, handler);
       done();
     });
@@ -31,5 +29,5 @@ describe('copyText', () => {
       expect(navigator.share.args[0][0].text).to.equal('bogus');
     });
   });
-  
+
 });

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -42,8 +42,14 @@ function filterHiddenEntries (entries) {
   });
 };
 
-function applyFilters (query, list) {
+function filterByFavorited (entries) {
+  if(!entries) return entries;
+  return entries.filter(entry => !!entry.favorited);
+};
+
+function applyFilters (query, filter, list) {
   list = filterHiddenEntries(list);
+  if(filter === 'favorites') list = filterByFavorited(list);
   return filterObjectsByText(query, list);
 };
 

--- a/client/js/utils/index.js
+++ b/client/js/utils/index.js
@@ -47,7 +47,8 @@ function filterByFavorited (entries) {
   return entries.filter(entry => !!entry.favorited);
 };
 
-function applyFilters (query, filter, list) {
+function applyFilters (query, filter, showFilterInput, list) {
+  if(showFilterInput && !query && !filter) return [];
   list = filterHiddenEntries(list);
   if(filter === 'favorites') list = filterByFavorited(list);
   return filterObjectsByText(query, list);

--- a/client/js/utils/index.spec.js
+++ b/client/js/utils/index.spec.js
@@ -27,7 +27,7 @@ describe('utils', () => {
 
   describe('removeObjectByIndex', () => {
     let list = [ { id: 0 }, { id: 1 }, { id: 2 } ];
-    
+
     it('should remove the item at the given index', () => {
       removeObjectByIndex(1, list);
       expect(list[1].id).to.equal(2);
@@ -56,23 +56,23 @@ describe('utils', () => {
       { date: '2', text: 'c' },
       { date: 'c', text: '2' }
     ];
-    
+
     it('should return input list if query is falsey', () => {
       const filtered = filterObjectsByText('', list);
       expect(filtered).to.equal(list);
     });
-    
+
     it('should return empty list if query is not found', () => {
       const filtered = filterObjectsByText('z', list);
       expect(filtered.length).to.equal(0);
     });
-    
+
     it('should find entries with matching date content', () => {
       const filtered = filterObjectsByText('0', list);
       expect(filtered.length).to.equal(1);
       expect(filtered[0].date).to.equal('0');
     });
-    
+
     it('should find entries with matching text content even when the query is capitalized', () => {
       let filtered = filterObjectsByText('b', list);
       expect(filtered.length).to.equal(1);
@@ -82,7 +82,7 @@ describe('utils', () => {
       expect(filtered.length).to.equal(1);
       expect(filtered[0].date).to.equal('1');
     });
-    
+
     it('should find entries with matching date and/or text content', () => {
       const filtered = filterObjectsByText('c', list);
       expect(filtered.length).to.equal(2);
@@ -111,18 +111,38 @@ describe('utils', () => {
   /* I need to spend more time with this test. The spies are incorrect somehow. */
   describe('applyFilters', () => {
     const query = 'query';
+    let filter = 'favorites';
+    // let showFilterInput = false;
     const list = [
-      { deleted: '1' },
-      { date: '1', text: '' },
-      { date: '1', text: 'query' },
-      { date: 'query', text: '1' }
+      { deleted: '1', text: query },
+      { date: '0', text: '', favorited: true },
+      { date: '1', text: query, favorited: true },
+      { date: query, text: '1' }
     ];
 
-    it('should call filterHiddenEntries and filterObjectsByText', () => {
-      const filtered = applyFilters(query, list);
+    it('should return an empty list when query and filter are falsey and showFilterInput is true', () => {
+      const filtered = applyFilters('', '', true, list);
+      expect(filtered.length).to.equal(0);
+    });
+
+    it('should return entries containing query (excluding deleted)', () => {
+      const filtered = applyFilters(query, '', false, list);
       expect(filtered.length).to.equal(2);
       expect(filtered[0].text).to.equal(query);
       expect(filtered[1].date).to.equal(query);
+    });
+
+    it('should return favorited entries (excluding deleted)', () => {
+      const filtered = applyFilters('', filter, false, list);
+      expect(filtered.length).to.equal(2);
+      expect(filtered[0].text).to.equal('');
+      expect(filtered[1].text).to.equal(query);
+    });
+
+    it('should return favorited entries containing query (excluding deleted)', () => {
+      const filtered = applyFilters(query, filter, false, list);
+      expect(filtered.length).to.equal(1);
+      expect(filtered[0].text).to.equal(query);
     });
   });
 
@@ -131,7 +151,7 @@ describe('utils', () => {
     const newHref = '/entry/new';
     const entriesHref = '/entries'
     const entryHref = '/entry/1234'
-    
+
     it('should return /new if href contains /new', () => {
       expect(getViewFromPathname(newHref)).to.equal('/new');
     });
@@ -143,7 +163,7 @@ describe('utils', () => {
     it('should return /entries when passed /entries', () => {
       expect(getViewFromPathname(entriesHref)).to.equal('/entries');
     });
-    
+
     it('should return / when passed /', () => {
       expect(getViewFromPathname(rootHref)).to.equal('/');
     });
@@ -187,5 +207,5 @@ describe('utils', () => {
       });
     });
   });
-  
+
 });

--- a/server/bl/entry-bl.js
+++ b/server/bl/entry-bl.js
@@ -1,5 +1,7 @@
 module.exports = function(Entry){
   var self = this;
+  const fourOhFour = { status: 400, message: 'Timestamp is required.' };
+  const fiveHundred = { status: 500, message: 'There was an error.' };
 
   self.getAllEntriesByOwnerId = function({body, query, user}){
     return new Promise(function (resolve, reject){
@@ -7,19 +9,20 @@ module.exports = function(Entry){
         if(entries && entries.rows) return resolve(entries.rows);
         return reject({status: 500, message: 'There was an error.'});
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }
 
   self.getUpdatesSinceTimestamp = function({body, query, params, user}){
     return new Promise(function (resolve, reject){
-      if(!params.timestamp) return reject({status: 400, message: 'Timestamp is required.'});
-      Entry.getUpdatesSinceTimestamp(user.id, parseInt(params.timestamp, 10), user.deviceId).then(function (entries){
-        if(!entries) return reject({status: 500, message: 'There was an error.'});
+      if(!params.timestamp) return reject(fourOhFour);
+      const timestamp = parseInt(params.timestamp, 10);
+      Entry.getUpdatesSinceTimestamp(user.id, timestamp, user.deviceId).then(function (entries){
+        if(!entries) return reject(fiveHundred);
         return resolve(entries);
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }
@@ -28,13 +31,12 @@ module.exports = function(Entry){
     return new Promise(function (resolve, reject){
       var entryId = parseInt(params.id, 10);
       Entry.getEntryById(entryId).then(function (entry){
-        if(!entry) return reject({status: 404, message: 'Entry not found.'});
-        if(user.id !== entry.ownerId) return reject({status: 404, message: 'Entry not found.'});
+        if(!entry || user.id !== entry.ownerId) return reject(fourOhFour);
         entry.isOwner = (user && user.id == entry.ownerId);
         delete entry.ownerId;
         return resolve(entry);
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }
@@ -44,7 +46,7 @@ module.exports = function(Entry){
       Entry.createEntry(body, user.id, user.deviceId).then(function (entry){
         return resolve(entry.id);
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }
@@ -53,15 +55,14 @@ module.exports = function(Entry){
     return new Promise(function (resolve, reject){
       var entryId = parseInt(params.id, 10);
       Entry.getEntryById(entryId).then(function (entry){
-        if(!entry) return reject({status: 404, message: 'Entry not found.'});
-        if(user.id !== entry.ownerId) return reject({status: 404, message: 'Entry not found.'});
+        if(!entry || user.id !== entry.ownerId) return reject(fourOhFour);
         Entry.updateEntry(entryId, body, user.deviceId).then(function (response){
           return resolve();
         }, function (err){
           return reject(err);
         });
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }
@@ -70,15 +71,14 @@ module.exports = function(Entry){
     return new Promise(function (resolve, reject){
       var entryId = parseInt(params.id, 10);
       Entry.getEntryById(entryId).then(function (entry){
-        if(!entry) return reject({status: 404, message: 'Entry not found.'});
-        if(user.id !== entry.ownerId) return reject({status: 404, message: 'Entry not found.'});
+        if(!entry || user.id !== entry.ownerId) return reject(fourOhFour);
         Entry.deleteEntry(params.id, user.deviceId).then(function (response){
           return resolve();
         }, function (err){
           return reject(err);
         });
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }
@@ -88,7 +88,7 @@ module.exports = function(Entry){
       Entry.getEntryCount().then(function (total){
         return resolve(total);
       }, function (err){
-        return reject({status: 500, message: err});
+        return reject(fiveHundred);
       });
     });
   }

--- a/server/middleware/entry-handlers.js
+++ b/server/middleware/entry-handlers.js
@@ -1,8 +1,15 @@
 var date = require('../utils/date');
 
+const removeFalseyFavorited = entry => {
+  if(entry.favorited === 0){
+    delete entry.favorited;
+  }
+  return entry;
+};
+
 exports.getAllEntriesByOwnerId = function(req, res, entries){
   res.send({
-    entries: entries,
+    entries: entries.map(removeFalseyFavorited),
     timestamp: date.getUtcZeroTimestamp()
   });
 }

--- a/server/models/entry-model.js
+++ b/server/models/entry-model.js
@@ -5,6 +5,7 @@ module.exports = function(sequelize, Sequelize){
     date: Sequelize.DATE,
     text: Sequelize.TEXT,
     updatedAt: {type: Sequelize.INTEGER(15), field: 'updated_at'},
+    favorited: Sequelize.BOOLEAN,
     deleted: Sequelize.BOOLEAN,
     deviceId: {type: Sequelize.STRING(5), field: 'device_id'},
   }, {timestamps: false});

--- a/server/services/entry-service.js
+++ b/server/services/entry-service.js
@@ -10,7 +10,7 @@ module.exports = function(Entry, sequelize){
         deleted: { $ne: 1 }
       },
       attributes: [
-        'id', 'date', 'text',
+        'id', 'date', 'text', 'favorited',
         [sequelize.fn('date_format', sequelize.col('date'), '%Y-%m-%d'), 'date'],
       ],
       order: [
@@ -29,7 +29,7 @@ module.exports = function(Entry, sequelize){
         deviceId: { $ne: deviceId }
       },
       attributes: [
-        'id', 'date', 'text', 'deleted',
+        'id', 'date', 'text', 'deleted', 'favorited',
         [sequelize.fn('date_format', sequelize.col('date'), '%Y-%m-%d'), 'date'],
       ],
       order: [
@@ -42,9 +42,9 @@ module.exports = function(Entry, sequelize){
 
   self.getEntryById = function(id){
     return Entry.findOne({
-      where: {id: id},
+      where: { id: id },
       attributes: [
-        'id', 'ownerId', 'text',
+        'id', 'ownerId', 'text', 'favorited',
         [sequelize.fn('date_format', sequelize.col('date'), '%Y-%m-%d'), 'date'],
       ],
       raw: true
@@ -57,6 +57,7 @@ module.exports = function(Entry, sequelize){
         ownerId: ownerId,
         date: data.date,
         text: data.text,
+        favorited: 0,
         updatedAt: date.getUtcZeroTimestamp(),
         deviceId: deviceId
       }).then(function (entry){
@@ -81,11 +82,12 @@ module.exports = function(Entry, sequelize){
       text: '',
       deleted: 1,
       updatedAt: date.getUtcZeroTimestamp(),
+      favorited: 0,
       deviceId: deviceId
     };
 
     return Entry.update(data, {
-      where: {id: entryId}
+      where: { id: entryId }
     });
   }
 

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -38,12 +38,12 @@ module.exports = {
     ]
   },
   plugins: [
-    // new UglifyJSPlugin({
-    //   uglifyOptions: {
-    //     keep_fargs: false,
-    //     passes: 3
-    //   }
-    // })
+    new UglifyJSPlugin({
+      uglifyOptions: {
+        keep_fargs: false,
+        passes: 3
+      }
+    })
   ],
   output: {
     filename: 'bundle.js',

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -38,12 +38,12 @@ module.exports = {
     ]
   },
   plugins: [
-    new UglifyJSPlugin({
-      uglifyOptions: {
-        keep_fargs: false,
-        passes: 3
-      }
-    })
+    // new UglifyJSPlugin({
+    //   uglifyOptions: {
+    //     keep_fargs: false,
+    //     passes: 3
+    //   }
+    // })
   ],
   output: {
     filename: 'bundle.js',


### PR DESCRIPTION
## Features

* Add favorites--can favorite entries online and offline. Syncs when online just like everything else about entries. Filter entries by favorites. Replace entry preview delete icon with favorite icon. Don't send `favorited` property from `getAllEntriesByOwnerId` unless `favorited` is 1.
* Better dark mode--scrolling quickly no longer shows a white background while the virtual scroll catches up.
* Adding dialogs/modals--stop using the toast for the app menu and delete confirmation. Also add a logout confirmation modal.
* More obvious search--set viewEntries to empty array upon entering search mode. Add entry count to search field.
* Simplify toast--only show it as a copied to clipboard notification. Switch it to a functional component and move logic into an action.
* Update tests.

## Size

Master: **14.19kb**
This PR: **15.03kb**

Why? These changes add the following:

* Two new icons--`star-empty` and `star-filled`
* Two new components--`dialog` and `dialog-wrapper`
* A bunch of CSS--dialog styles and search form styles
* Plumbing for favorites, filters, and improved dark mode--`app-state`, `entry-actions`, and `utils`