### PR TITLE
Centralize optimistic save dance and fix three race conditions

### DIFF
--- a/client/js/actions/entry-actions.js
+++ b/client/js/actions/entry-actions.js
@@ -10,8 +10,8 @@ let dataFetched = false;
 
 function updateIdbEntries (userId, updater) {
   get('entries_' + userId).then((entries = []) => {
-    var updated = updater(entries);
-    if(updated !== false) set('entries_' + userId, sortObjectsByDate(updated || entries));
+    var updated = updater(entries) || entries;
+    set('entries_' + userId, sortObjectsByDate(updated));
   });
 }
 
@@ -19,6 +19,26 @@ function isStaleUser (el, userId, updater) {
   if(el.state.userId === userId) return false;
   if(updater) updateIdbEntries(userId, updater);
   return true;
+}
+
+function applyEntryPatch (el, userId, id, patch) {
+  // userId is optional; pass undefined to skip the stale-user check
+  // (e.g. on failure paths where the response userId isn't available).
+  if(userId !== undefined && isStaleUser(el, userId, entries => {
+    var idx = findObjectIndexById(id, entries);
+    if(idx > -1) patch(entries, idx);
+  })) return;
+
+  var entries = el.state.entries;
+  var idx = findObjectIndexById(id, entries);
+  if(idx === -1) return;
+  patch(entries, idx);
+
+  var entry = isActiveEntryId(el, id) && entries[idx]
+    ? Object.assign({}, entries[idx])
+    : el.state.entry;
+
+  el.set({ entry, entries: entries.slice() });
 }
 
 function boot (el, { entries }){
@@ -202,66 +222,34 @@ function createEntry (el, { entry, clientSync }){
     .catch(() => createEntryFailure(el, entry.id));
 };
 
+/**
+ * Because needsSync is a boolean, removing it here
+ * can introduce a problem.
+ *
+ * For example, if I type one character and pause,
+ * thereby triggering a POST, that will add the
+ * needsSync and postPending flags to the entry. As
+ * a result, anything I type while the POST is
+ * pending (which would normally trigger adding the
+ * needsSync flag to the entry) will be ignored when
+ * the POST returns and triggers a removal of the
+ * entry's needsSync flag.
+ *
+ * A potential solution could be to make needsSync
+ * an integer so I can increment it when it needs
+ * both a POST and a PATCH.
+ */
 function createEntrySuccess (el, userId, oldId, id){
-  if(isStaleUser(el, userId, entries => {
-    var idx = findObjectIndexById(oldId, entries);
-    if(idx > -1) {
-      entries[idx].id = id;
-      delete entries[idx].postPending;
-      delete entries[idx].newEntry;
-      delete entries[idx].needsSync;
-    }
-  })) return;
-
-  var entryIndex = findObjectIndexById(oldId, el.state.entries);
-
-  /**
-   * Only update state.entry if the entry we just
-   * modified is still active.
-   */
-  if(isActiveEntryId(el, oldId)) el.state.entry.id = id;
-
-  el.state.entries[entryIndex].id = id;
-  delete el.state.entries[entryIndex].postPending;
-  delete el.state.entries[entryIndex].newEntry;
-  /**
-   * Because needsSync is a boolean, removing it here
-   * can introduce a problem.
-   *
-   * For example, if I type one character and pause,
-   * thereby triggering a POST, that will add the
-   * needsSync and postPending flags to the entry. As
-   * a result, anything I type while the POST is
-   * pending (which would normally trigger adding the
-   * needsSync flag to the entry) will be ignored when
-   * the POST returns and triggers a removal of the
-   * entry's needsSync flag.
-   *
-   * A potential solution could be to make needsSync
-   * an integer so I can increment it when it needs
-   * both a POST and a PATCH.
-   */
-  delete el.state.entries[entryIndex].needsSync;
-
-  el.set({
-    entry: Object.assign({}, el.state.entry),
-    entries: el.state.entries.slice()
+  applyEntryPatch(el, userId, oldId, (entries, i) => {
+    entries[i].id = id;
+    delete entries[i].postPending;
+    delete entries[i].newEntry;
+    delete entries[i].needsSync;
   });
 };
 
 function createEntryFailure (el, oldId){
-  /**
-   * Only update state.entry if the entry we just
-   * modified is still active.
-   */
-  if(isActiveEntryId(el, oldId)) delete el.state.entry.postPending;
-
-  var entryIndex = findObjectIndexById(oldId, el.state.entries);
-  delete el.state.entries[entryIndex].postPending;
-  el.set({
-    entry: Object.assign({}, el.state.entry),
-    entries: el.state.entries.slice()
-  });
+  applyEntryPatch(el, undefined, oldId, (entries, i) => { delete entries[i].postPending; });
 };
 
 function toggleFavorite (el, { id, favorited }){
@@ -294,24 +282,7 @@ function updateEntry (el, { entry, property, entryId }){
 };
 
 function updateEntrySuccess (el, userId, id){
-  if(isStaleUser(el, userId, entries => {
-    var idx = findObjectIndexById(id, entries);
-    if(idx > -1) delete entries[idx].needsSync;
-  })) return;
-
-  const entries = el.state.entries.slice();
-  const entryIndex = findObjectIndexById(id, entries);
-  delete entries[entryIndex].needsSync;
-
-  /**
-   * Only update state.entry if the entry we just
-   * modified is still active.
-   */
-  const entry = isActiveEntryId(el, id)
-    ? Object.assign({}, entries[entryIndex])
-    : el.state.entry;
-
-  el.set({ entry, entries });
+  applyEntryPatch(el, userId, id, (entries, i) => { delete entries[i].needsSync; });
 };
 
 function putEntry (el, { entry }){
@@ -351,14 +322,7 @@ function deleteEntry (el, { id }){
 };
 
 function deleteEntrySuccess (el, userId, id){
-  if(isStaleUser(el, userId, entries => {
-    var idx = findObjectIndexById(id, entries);
-    if(idx > -1) entries.splice(idx, 1);
-  })) return;
-
-  var entryIndex = findObjectIndexById(id, el.state.entries);
-  el.state.entries.splice(entryIndex, 1);
-  el.set({ entries: el.state.entries });
+  applyEntryPatch(el, userId, id, (entries, i) => entries.splice(i, 1));
 };
 
 function setEntry (el, { id }){

--- a/client/js/actions/index.spec.js
+++ b/client/js/actions/index.spec.js
@@ -1,4 +1,5 @@
 import fetchMock from 'fetch-mock';
+import { get as idbGet, set as idbSet } from 'idb-keyval';
 import Global from './global-actions';
 import User from './user-actions';
 import Entry from './entry-actions';
@@ -898,6 +899,36 @@ describe('actions', () => {
         });
       });
 
+      // Covers the stale-user branch in applyEntryPatch (shared by all four callers).
+      // Models a real production race: user fires a request, switches accounts before
+      // the response lands, and the success handler should patch the original user's
+      // IDB cache rather than mutating the now-current user's in-memory state.
+      it('should patch IDB for the original user (not in-memory state) when the user switches accounts before the response arrives', (done) => {
+        fetchMock.patch('/api/entry/0', 204);
+
+        idbSet('entries_1', [{ id: 0, needsSync: true }]).then(() => {
+          Entry.updateEntry(el, {
+            entry: { date: '2017-01-01' },
+            property: 'date',
+            entryId: 0
+          });
+
+          // Simulate the user switching accounts before the response lands.
+          el.state.userId = '99';
+
+          setTimeout(() => {
+            // Stale path: the success handler should NOT call set a second time.
+            expect(el.set.calledTwice).to.be.false;
+
+            // But it SHOULD have patched user 1's IDB cache to clear needsSync.
+            idbGet('entries_1').then(entries => {
+              expect(entries[0].needsSync).to.be.undefined;
+              done();
+            });
+          }, 50);
+        });
+      });
+
     });
 
     describe('showConfirmDeleteEntryModal', () => {
@@ -961,6 +992,26 @@ describe('actions', () => {
 
         setTimeout(() => {
           expect(el.set.calledTwice).to.be.false;
+          done();
+        });
+      });
+
+      // Regression test for the applyEntryPatch idx === -1 guard. Also protects
+      // updateEntrySuccess, createEntrySuccess, and createEntryFailure, which all share the same helper.
+      it('should not corrupt entries when the target is removed from state before the delete response resolves', (done) => {
+        fetchMock.delete('/api/entry/0', 204);
+        el.state.entries.push({ id: 99 });
+        Entry.deleteEntry(el, { id: 0 });
+
+        // Simulate the entry being removed from state before the response arrives
+        // (e.g. by an account switch or a server-driven sync). Without the guard,
+        // splice(-1, 1) would remove { id: 99 } — the wrong entry.
+        el.state.entries = [{ id: 99 }];
+
+        setTimeout(() => {
+          expect(el.set.calledTwice).to.be.false;
+          expect(el.state.entries.length).to.equal(1);
+          expect(el.state.entries[0].id).to.equal(99);
           done();
         });
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,6 @@
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.12.0",
         "preact": "^8.3.1",
-        "select": "^1.1.2",
         "sequelize": "^6.37.5",
         "shrink-ray": "https://github.com/jpodwys/shrink-ray#master",
         "webpack": "^3.6.0"
@@ -11532,11 +11531,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
-    },
-    "node_modules/select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
     },
     "node_modules/semver": {
       "version": "5.7.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.12.0",
     "preact": "^8.3.1",
-    "select": "^1.1.2",
     "sequelize": "^6.37.5",
     "shrink-ray": "https://github.com/jpodwys/shrink-ray#master",
     "webpack": "^3.6.0"


### PR DESCRIPTION
## Summary
- Extracts the repeated stale-user-aware patch dance from the entry-actions success/failure handlers into a single `applyEntryPatch` helper. Used by `createEntrySuccess`, `updateEntrySuccess`, `deleteEntrySuccess`, and `createEntryFailure`.
- Fixes three latent race conditions in those handlers (silent state corruption in delete, swallowed `TypeError` in update + createFailure) via the helper's `idx === -1` guard. Triggered when the target entry is removed from state between the request firing and the response landing.
- Drops a dead-code branch in `updateIdbEntries` (no caller ever returns `false` from its updater).
- Removes the unused `select` npm dependency.
- Adds two regression tests: one for the delete corruption guard (also protects update/create via the shared helper), and one for the previously-untested stale-user IDB-patch path.

## Net impact
- 162 tests pass (was 160; +2 regression tests; 1 pre-existing skipped test unchanged).
- `entry-actions.js`: net -15 source lines after extraction.
- Bundle size moved by tens of bytes — not a meaningful change in either direction. The point of this PR is correctness and centralization, not bytes.

## Test plan
- [x] `npm test` — 162 passing
- [x] `npm run build` — builds clean
- [x] Verified each new regression test fails when its corresponding guard is removed