### PR TITLE
Precompress static assets at build time with brotli q11

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var express = require('express'),
   cookieParser = require('cookie-parser'),
   app = express(),
   strictTransportSecurity = require('./server/middleware/strict-transport-security'),
+  precompressedStatic = require('./server/middleware/precompressed-static'),
   forceSsl = require('force-ssl-heroku'),
   jwtPrser = require('./server/middleware/jwt-parser'),
   cron = require('./server/cron'),
@@ -19,6 +20,7 @@ var express = require('express'),
 app.disable('x-powered-by');
 app.use(forceSsl);
 app.use(strictTransportSecurity);
+app.use(precompressedStatic('dist'));
 app.use(shrinkRay({ threshold: '1.4kb' }));
 // app.use(compression({ threshold: '1.4kb' }));
 app.use(bodyParser.urlencoded({ extended: true, limit: '50kb' }));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,8 +8,13 @@ var esbuild = require('esbuild');
 var browserslist = require('browserslist');
 var crypto = require('crypto');
 var fs = require('fs');
+var path = require('path');
+var zlib = require('zlib');
 var del = require('del');
 var replace = require('gulp-replace');
+
+var COMPRESSIBLE_EXTS = /\.(html|js|css|json|svg|txt)$/i;
+var PRECOMPRESS_MIN_BYTES = 1400; // matches shrinkRay threshold
 
 function serve(cb) {
   require('./app.js');
@@ -93,13 +98,31 @@ function cspHash(cb) {
   cb();
 }
 
+function precompress(cb) {
+  fs.readdirSync('./dist').forEach(function (name) {
+    if (!COMPRESSIBLE_EXTS.test(name)) return;
+    var full = path.join('./dist', name);
+    var buf = fs.readFileSync(full);
+    if (buf.length < PRECOMPRESS_MIN_BYTES) return;
+    var br = zlib.brotliCompressSync(buf, {
+      params: {
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 11,
+        [zlib.constants.BROTLI_PARAM_SIZE_HINT]: buf.length
+      }
+    });
+    fs.writeFileSync(full + '.br', br);
+  });
+  cb();
+}
+
 function build(cb) {
   return gulp.series(
     clean,
     gulp.parallel(scripts, sw, version, manifest, images),
     gulp.parallel(styles, compress),
     inline,
-    cspHash
+    cspHash,
+    precompress
   )(cb);
 }
 

--- a/server/middleware/precompressed-static.js
+++ b/server/middleware/precompressed-static.js
@@ -1,0 +1,42 @@
+var fs = require('fs');
+var path = require('path');
+
+var TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js':   'application/javascript; charset=utf-8',
+  '.css':  'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg':  'image/svg+xml',
+  '.txt':  'text/plain; charset=utf-8'
+};
+
+module.exports = function precompressedStatic(rootDir) {
+  var absRoot = path.resolve(rootDir);
+
+  return function (req, res, next) {
+    if (req.method !== 'GET' && req.method !== 'HEAD') return next();
+
+    var accept = req.headers['accept-encoding'] || '';
+    if (!/\bbr\b/.test(accept)) return next();
+
+    var urlPath = req.path === '/' ? '/index.html' : req.path;
+    var ext = path.extname(urlPath).toLowerCase();
+    if (!TYPES[ext]) return next();
+
+    var absFile = path.resolve(absRoot, '.' + urlPath);
+    if (absFile !== absRoot && absFile.indexOf(absRoot + path.sep) !== 0) return next();
+
+    var brPath = absFile + '.br';
+    fs.stat(brPath, function (err, stat) {
+      if (err || !stat.isFile()) return next();
+
+      res.setHeader('Content-Type', TYPES[ext]);
+      res.setHeader('Content-Encoding', 'br');
+      res.setHeader('Content-Length', stat.size);
+      res.setHeader('Vary', 'Accept-Encoding');
+
+      if (req.method === 'HEAD') return res.end();
+      fs.createReadStream(brPath).pipe(res);
+    });
+  };
+};


### PR DESCRIPTION
## Summary
- `shrinkRay` does dynamic compression at brotli quality 4 on the first request to a URL, then asynchronously re-encodes the LRU-cached entry at quality 11 for subsequent hits. Cold-cache requests (first user after a deploy, SW re-fetching after sw.js updates, hard refresh) therefore land at q4 — about 1.8KB heavier than steady-state on the served `index.html`.
- This PR closes that cliff by precompressing all compressible static assets at build time at brotli quality 11, then serving the precompressed file directly when the client supports brotli. shrinkRay continues to handle dynamic responses (API endpoints) unchanged.

## Changes
- `gulpfile.js` — new `precompress` task at the end of the build pipeline. Walks `dist/`, brotli-q11s every compressible file (`.html .js .css .json .svg .txt`) over 1.4KB, writes a sibling `.br` file.
- `server/middleware/precompressed-static.js` — new ~30-line middleware. On `GET`/`HEAD` with `Accept-Encoding: br`, looks for the alongside `.br` file and streams it with proper `Content-Encoding` / `Vary` / `Content-Length` / `Content-Type`. Falls through for non-brotli clients or paths without a precompressed sibling.
- `app.js` — mounts the new middleware between `strictTransportSecurity` and `shrinkRay`.

## Sizes (brotli q11, after precompress)
| File | Raw | q11 | Ratio |
|---|---|---|---|
| `index.html` (the SPA) | 41,611 | **12,934** | 31% |
| `bundle.js` | 33,948 | 11,048 | 32% |
| `styles.css` | 7,156 | 1,800 | 25% |

Skipped (correctly): all images (already binary-compressed) and files under the 1.4KB threshold (`sw.js` 955B, `manifest.json` 382B, `version.json` 32B, `csp-hash.json` 55B).

## Test plan
- [x] `npm run build` produces `dist/index.html.br`, `dist/bundle.js.br`, `dist/styles.css.br`
- [x] Smoke-tested middleware end-to-end (mounted alone with `express.static`):
  - With `Accept-Encoding: br`: serves `.br` file, correct `Content-Encoding: br`, `Vary: Accept-Encoding`, `Content-Type`, `Content-Length`
  - Without brotli: falls through to `express.static`, serves uncompressed
  - `HEAD` returns headers only with correct `Content-Length`
  - Path-traversal attempts (`/../package.json`) return 404
  - Non-existent files fall through to express.static (404)
- [x] `npm test` — 160 client tests still pass (unchanged; this PR is server-only)