### PR TITLE
Comment out IDB connection warming script

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -11,7 +11,7 @@
     <title>Journalize</title>
   </head>
   <body>
-    <script>var r=indexedDB.open('keyval-store',1);r.onupgradeneeded=function(){r.result.createObjectStore('keyval')};</script>
+    <!-- <script>var r=indexedDB.open('keyval-store',1);r.onupgradeneeded=function(){r.result.createObjectStore('keyval')};</script> -->
     <script src="/bundle.js" inline cachehint="eager"></script>
     <noscript>
       Please enable JavaScript.

--- a/client/index.html
+++ b/client/index.html
@@ -11,6 +11,7 @@
     <title>Journalize</title>
   </head>
   <body>
+    <!-- This is an idb cache warming line but it seems to haveno perceptible impact on my phone. Commenting it in case I want to revisit it later. -->
     <!-- <script>var r=indexedDB.open('keyval-store',1);r.onupgradeneeded=function(){r.result.createObjectStore('keyval')};</script> -->
     <script src="/bundle.js" inline cachehint="eager"></script>
     <noscript>


### PR DESCRIPTION
## Summary
- Comments out the inline `indexedDB.open` warming script in `client/index.html`. Empirical testing on a Pixel 9 PWA showed no perceptible boot-time difference with the warming removed, and estimated savings (~5–25ms cold, ~0–5ms warm) are below the perceptual floor on the devices in use.
- Leaves the script in place as a comment with an explanatory note in case the optimization is ever worth revisiting (e.g., on slower target devices or with substantially larger IDB blobs).
- The build pipeline strips HTML comments via `htmlmin`'s `removeComments`, so deployed `dist/index.html` contains neither the script nor the comments.

## Test plan
- [ ] Build the project (`gulp build`) and confirm `dist/index.html` does not contain the warming script or its surrounding comments.
- [ ] Deploy and verify boot still works (entries load from IDB on app open).