### PR TITLE
Remove manual scrollPosition tracking

### DIFF
--- a/client/components/entries/index.js
+++ b/client/components/entries/index.js
@@ -1,29 +1,16 @@
 import { h, Component } from 'preact';
 import ScrollViewport from '../virtual-scroll';
 import EntryPreview from '../entry-preview';
-import { fire } from '../unifire';
-import debounce from '../../js/debounce';
 
 export default class Entries extends Component {
-  componentDidMount() {
-    document.body.onscroll = debounce(() => {
-      fire('linkstate', { key: 'scrollPosition', val: document.body.scrollTop });
-    }, 50);
-  }
-
-  componentWillUnmount() {
-    document.body.onscroll = null;
-  }
-
   shouldComponentUpdate(np) {
     return this.props.viewEntries !== np.viewEntries;
   }
 
-  render({ viewEntries = [], scrollPosition, filterText }) {
+  render({ viewEntries = [], filterText }) {
     if(!viewEntries.length){
       return <h2 class="center-text fade-up entry-text">It's empty in here!</h2>
     }
-    document.body.scrollTop = scrollPosition;
 
     const renderer = (items) => {
       return items.map(entry => <EntryPreview entry={entry} filterText={filterText}/>)

--- a/client/components/entries/index.spec.js
+++ b/client/components/entries/index.spec.js
@@ -1,34 +1,18 @@
 import { h } from 'preact';
-import { mount, fireEvent } from '../../../test/mount';
+import { mount } from '../../../test/mount';
 import Entries from './index';
 
 describe('entries', () => {
   let env;
 
-  // In headless Chrome, document.scrollingElement is documentElement and
-  // body.scrollTop assignments don't stick. Production reads/writes body
-  // .scrollTop directly, so shim it for tests to observe both directions.
-  // The override is body-only (Element.prototype is untouched), so deleting
-  // the body's own property restores the prototype lookup chain.
-  let bodyScrollTop = 0;
-  before(() => {
-    Object.defineProperty(document.body, 'scrollTop', {
-      configurable: true,
-      get() { return bodyScrollTop; },
-      set(v) { bodyScrollTop = v; }
-    });
-  });
-  after(() => { delete document.body.scrollTop; });
-
   afterEach(() => {
     if(env) env.cleanup();
     env = null;
-    bodyScrollTop = 0;
   });
 
   function mountEntries (state = {}, actions = {}) {
     return mount(h(Entries, null), {
-      state: Object.assign({ viewEntries: [], scrollPosition: 0, filterText: '' }, state),
+      state: Object.assign({ viewEntries: [], filterText: '' }, state),
       actions
     });
   }
@@ -50,47 +34,5 @@ describe('entries', () => {
     expect(env.host.querySelector('.entry-preview')).to.exist;
     // The first entry's date appears via the rendered EntryPreview.
     expect(env.getByText('2024-01-01')).to.exist;
-  });
-
-  it('installs and removes the body scroll listener across mount/unmount', () => {
-    document.body.onscroll = null;
-    env = mountEntries();
-    expect(document.body.onscroll).to.be.a('function');
-    env.cleanup();
-    env = null;
-    expect(document.body.onscroll).to.be.null;
-  });
-
-  it('applies state.scrollPosition to document.body.scrollTop on render', () => {
-    env = mountEntries({
-      viewEntries: [{ id: 1, date: '2024-01-01', text: 'a' }],
-      scrollPosition: 250
-    });
-    expect(document.body.scrollTop).to.equal(250);
-  });
-
-  describe('body scroll listener', () => {
-    let clock;
-    beforeEach(() => { clock = sinon.useFakeTimers(); });
-    afterEach(() => clock.restore());
-
-    it('fires linkstate with the new scrollPosition after the 50ms debounce', () => {
-      const linkstate = sinon.spy();
-      env = mountEntries(
-        { viewEntries: [{ id: 1, date: 'd', text: 't' }] },
-        { linkstate }
-      );
-
-      document.body.scrollTop = 137;
-      fireEvent(document.body, 'scroll');
-      expect(linkstate.called).to.be.false;
-      clock.tick(50);
-
-      expect(linkstate.calledOnce).to.be.true;
-      expect(linkstate.args[0][1]).to.deep.equal({
-        key: 'scrollPosition',
-        val: 137
-      });
-    });
   });
 });

--- a/client/components/search/index.js
+++ b/client/components/search/index.js
@@ -3,7 +3,7 @@ import Entries from '../entries';
 import Icon from '../icon';
 import { fire } from '../unifire';
 
-export default ({ filter, filterText, viewEntries = [], scrollPosition }) => {
+export default ({ filter, filterText, viewEntries = [] }) => {
   if(!viewEntries.length){
     if(!filter && !filterText){
       return (
@@ -27,7 +27,6 @@ export default ({ filter, filterText, viewEntries = [], scrollPosition }) => {
 
   return (
     <Entries
-      scrollPosition={scrollPosition}
       viewEntries={viewEntries}
       filterText={filterText}/>
   );

--- a/client/js/app-state/index.js
+++ b/client/js/app-state/index.js
@@ -58,7 +58,6 @@ export default function getInitialState () {
     username,
     entries: [],
     viewEntries: [],
-    scrollPosition: 0,
     sort: 'desc',
     filter: '',
     filterText: '',

--- a/client/js/app-state/index.spec.js
+++ b/client/js/app-state/index.spec.js
@@ -21,7 +21,6 @@ describe('appState', () => {
 
     expect(localStorage.getItem('bogus')).to.be.null;
     expect(typeof state).to.equal('object');
-    expect(state.scrollPosition).to.equal(0);
     expect(state.view).to.equal('/');
     expect(state.filterText).to.equal('');
     expect(state.loggedIn).to.be.false;


### PR DESCRIPTION
Browser-native scroll restoration on popstate handles back-nav adequately for the entries list. The manual restore was also re-applying stale scroll on every viewEntries change (e.g. filter typing in search), which caused unwanted jumps.